### PR TITLE
feat(compose): Implement compose function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
-  # - "node"
-  # - "7"
+  - "node"
+  - "8"
+  - "7"
   - "6"
+  - "5"
+  - "4"
 
 # Cache dependencies in $HOME/.yarn-cache across builds
 cache: yarn

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 A collection of higher-order components (HOCs) to easily create composite events in React components.
 
-> `react-composite-events` is currently under initial API design and not available for public use! Check out the [API Docs](#api-docs) for more info.
+> `react-composite-events` is currently under alpha development and not available for general public use! Check out the [API Docs](#api-docs) for more info.
 
-`react-composite-events` is heavily inspired by the [`Uize.Dom.VirtualEvent`](https://github.com/UIZE/UIZE-JavaScript-Framework/blob/master/site-source/js/Uize/Dom/VirtualEvent.js) module that is a part of the open-source [UIZE JavaScript Framework](https://github.com/UIZE/UIZE-JavaScript-Framework). It is stable, [dependency-free](https://david-dm.org/benmvp/react-composite-events#info=dependencies), [heavily-tested](https://coveralls.io/github/benmvp/react-composite-events?branch=master) and [well-documented](#api-docs).
+`react-composite-events` is [stable](https://travis-ci.org/benmvp/react-composite-events), [heavily-tested](https://coveralls.io/github/benmvp/react-composite-events?branch=master) and [well-documented](#api-docs).
 
 ## ToC
 
@@ -29,6 +29,8 @@ A collection of higher-order components (HOCs) to easily create composite events
 - [What is a Composite Event?](#what-is-a-composite-event)
 - [Benefits of Composite Events](#benefits-of-composite-events)
 - [API Docs](#api-docs)
+- [Target Environments](#target-environments)
+- [Prior Art](#prior-art)
 - [Contributing](CONTRIBUTING.md)
 - [Project philosophy](#project-philosophy)
 - [License](LICENSE)
@@ -118,6 +120,14 @@ The Composite Event HOCs are grouped by domain:
 - [**Generic**](src/generic/) - geneirc HOCs that create composite events intended to be environment-agnostic
 - [**Mouse**](src/mouse/) - the HOCs that create composite events around DOM mouse events
 - [**Key**](src/key/) - the HOCs that create composite events around DOM keyboard events
+
+## Target Environments
+
+TBD...
+
+## Prior Art
+
+`react-composite-events` is heavily inspired by the [`Uize.Dom.VirtualEvent`](https://github.com/UIZE/UIZE-JavaScript-Framework/blob/master/site-source/js/Uize/Dom/VirtualEvent.js) module that is a part of the open-source [UIZE JavaScript Framework](https://github.com/UIZE/UIZE-JavaScript-Framework). 
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -32,12 +32,17 @@
         "env",
         {
           "targets": {
-            "node": "4.5"
+            "node": "4.5",
+            "browsers": [
+              "last 2 versions"
+            ]
           }
         }
       ],
+      "stage-3",
       "react"
-    ]
+    ],
+    "plugins": ["transform-class-properties"]
   },
   "eslintConfig": {
     "extends": "eventbrite-react",
@@ -46,14 +51,26 @@
         "error",
         2
       ],
+      "no-invalid-this": "off",
       "semi": [
         "error",
         "never"
+      ],
+      "react/jsx-indent": [
+        "error",
+        2
+      ],
+      "react/jsx-indent-props": [
+        "error",
+        2
       ]
     },
     "env": {
       "jest": true
     }
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js"
   },
   "peerDependencies": {
     "react": ">=15"
@@ -62,8 +79,10 @@
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.0.0",
     "babel-jest": "^20.0.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
     "enzyme": "^2.9.1",
     "eslint": "^3.0.0",
     "eslint-config-eventbrite-react": "^5.0.0",
@@ -72,11 +91,16 @@
     "eslint-plugin-react": "^6.0.0",
     "husky": "^0.14.3",
     "jest": "^20.0.4",
+    "jest-enzyme": "^3.6.1",
     "lint-staged": "^4.0.1",
     "prettier-eslint-cli": "^4.1.1",
-    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1"
+  },
+  "dependencies": {
+    "array-to-lookup": "^1.0.1",
+    "lodash.omit": "^4.5.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     "validate": "npm run lint && npm test"
   },
   "lint-staged": {
-    "*.js": [
-      "npm run format",
-      "git add"
-    ]
+    "*.js": ["npm run format", "git add"]
   },
   "babel": {
     "presets": [
@@ -32,10 +29,8 @@
         "env",
         {
           "targets": {
-            "node": "4.5",
-            "browsers": [
-              "last 2 versions"
-            ]
+            "node": "4",
+            "browsers": ["last 2 versions"]
           }
         }
       ],
@@ -47,23 +42,11 @@
   "eslintConfig": {
     "extends": "eventbrite-react",
     "rules": {
-      "indent": [
-        "error",
-        2
-      ],
+      "indent": ["error", 2],
       "no-invalid-this": "off",
-      "semi": [
-        "error",
-        "never"
-      ],
-      "react/jsx-indent": [
-        "error",
-        2
-      ],
-      "react/jsx-indent-props": [
-        "error",
-        2
-      ]
+      "semi": ["error", "never"],
+      "react/jsx-indent": ["error", 2],
+      "react/jsx-indent-props": ["error", 2]
     },
     "env": {
       "jest": true

--- a/src/README.md
+++ b/src/README.md
@@ -163,6 +163,8 @@ If the `cancelEvent` occurs before the timer ends, the composite event is not co
 
 > If the `cancelEvent` matches an event passed to the enhanced component, it will be merged. For instance in the [`withMouseRest` example](#withmouserest-example), `onMouseOut` is one of the trigger events. If an `onMouseOut` handler was also passed to `<EnhancedDiv>` in addition `onMouseRest-500`, it will also be called.
 
+> If a [`triggerEvent`](#triggerevent) is also a `cancelEvent`, the composite event will never trigger; it will be immediately cancelled.
+
 ## `shouldResetTimerOnRetrigger`
 
 **(Optional)** A `boolean` specifying whether or not a [`triggerEvent`](#triggerevent) should reset the timer. If this optional configuration is not specified, then the value `true` will be used as the default.

--- a/src/README.md
+++ b/src/README.md
@@ -7,7 +7,6 @@ compose({
   ?defaultDuration: number = 0,
   ?cancelEvent: string | string[],
   ?shouldResetTimerOnRetrigger: boolean = true,
-  ?allowRefire: boolean = true,
   ?beforeCallback: (handler: (?event: Event) => void, ?event: Event) => void
 }): HigherOrderComponent
 ```
@@ -24,7 +23,6 @@ compose({
 - [`defaultDuration`](#defaultduration)
 - [`cancelEvent`](#cancelevent)
 - [`shouldResetTimerOnRetrigger`](#shouldresettimeronretrigger)
-- [`allowRefire`](#allowrefire)
 - [`beforeCallback`](#beforecallback)
 
 ## `withMouseRest` Example
@@ -41,7 +39,6 @@ const withMouseRest = compose({
   defaultDuration: 150,
   cancelEvent: ['onMouseOut', 'onMouseDown'],
   shouldResetTimerOnRetrigger: true,
-  allowRefire: false,
 })
 
 // wrap div with `withMouseRest` HOC configured to fire event
@@ -108,7 +105,7 @@ export default MyComponent extends PureComponent {
 }
 ```
 
-If `defaultDuration` isn't specified, or has a value less than or equal to `0`, `null` or `undefined`, then time will not be a factor in the composite event. The [`cancelEvent`](#cancelevent), [`shouldResetTimerOnRetrigger`](#shouldresettimeronretrigger) & [`allowRefire`](#allowrefire) configurations no longer apply. However, you will most likely make use of the [`beforeCallback`](#beforecallback) configuration.
+If `defaultDuration` isn't specified, or has a value less than or equal to `0`, `null` or `undefined`, then time will not be a factor in the composite event. The [`cancelEvent`](#cancelevent) & [`shouldResetTimerOnRetrigger`](#shouldresettimeronretrigger) configurations no longer apply. However, you will most likely make use of the [`beforeCallback`](#beforecallback) configuration.
 
 Typically `defaultDuration` is omitted when the initial [`triggerEvent`](#triggerevent) is enough to formulate the composite event. An example is a DOM event that modifier key properties such that you can create an `onCtrlClick` composite event. In this case time is not a factor in the composite event.
 
@@ -173,17 +170,11 @@ For the [`withMouseRest` example](#withmouserest-example), if another `onMouseMo
 
 `shouldResetTimerOnRetrigger` is ignored if [`defaultDuration`](#defaultduration) is unspecified.
 
-## `allowRefire`
-
-**(Optional)** A `boolean` specifying whether or not the composite event should be allowed to be refired after it has already fired once and before a `cancelEvent` has been fired. If this optional configuration is not specified, then the value `true` will be used as the default.
-
-`allowRefire` is ignored if [`defaultDuration`](#defaultduration) is unspecified.
-
 ## `beforeCallback`
 
 **(Optional)** A `function` that is called before composite event prop handler is ultimately called. The function receives two parameters: [`handler()`](#handler) & [`event`](#event).
 
-The `beforeCallback` function is most useful when [`defaultDuration`](#defaultduration) is unspecified. In these cases you're wanting to build the composite event from additional information in the [`event`](#event), and not based on a timer. Within `beforeCallback` you will need to explicitly call the [`handler()`](#handler) in order for the composite event prop handler to be called.
+The `beforeCallback` function is most useful when [`defaultDuration`](#defaultduration) is unspecified. In these cases you're wanting to build the composite event from additional information in the [`event`](#event), and not based on a timer. Within `beforeCallback` you will need to explicitly call the [`handler()`](#handler) (with the [`event`](#event)) in order for the composite event prop handler to be called.
 
 ### `handler()`
 
@@ -191,4 +182,4 @@ A `function` that is the composite event prop handler. This is what React compon
 
 ### `event`
 
-**(Optional)** An event `object` for the `triggerEvent`. For composite events that aren't time-based, you can use the `event` object to help compose the composite event. Some components may not have event objects for the `triggerEvent`, in which case `event` will be `undefined`. On the web, DOM elements will pass a DOM event for `event`.
+**(Optional)** An event `object` for the `triggerEvent`. For composite events that aren't time-based, you can use the `event` object to help compose the composite event. Some components may not have event objects for the `triggerEvent`, in which case `event` will be `undefined`. On the web, DOM elements will pass a DOM event for `event`. More often than not, you will want to pass `event` when you call [`handler()`](#handler).

--- a/src/README.md
+++ b/src/README.md
@@ -3,12 +3,12 @@
 ```js
 compose({
   eventPropName: string,
-  triggerEvent: string | Array<string>,
-  ?defaultDuration: integer = 0,
-  ?cancelEvent: string | Array<string>,
+  triggerEvent: string | string[],
+  ?defaultDuration: number = 0,
+  ?cancelEvent: string | string[],
   ?shouldResetTimerOnRetrigger: boolean = true,
   ?allowRefire: boolean = true,
-  ?beforeCallback: (handler: Function, ?event: Object) => void
+  ?beforeCallback: (handler: (?event: Event) => void, ?event: Event) => void
 }): HigherOrderComponent
 ```
 
@@ -37,9 +37,9 @@ import {compose} from 'react-composite-events'
 // options to `compose`
 const withMouseRest = compose({
   eventPropName: 'onMouseRest',
-  triggerEvent: ['onMouseOver','onMouseMove'],
+  triggerEvent: ['onMouseOver', 'onMouseMove'],
   defaultDuration: 150,
-  cancelEvent: ['onMouseOut','onMouseDown'],
+  cancelEvent: ['onMouseOut', 'onMouseDown'],
   shouldResetTimerOnRetrigger: true,
   allowRefire: false,
 })
@@ -73,7 +73,7 @@ The above call would make a parameterized composite event higher-order component
 
 ## `triggerEvent`
 
-**(Required)** A `string` name of an event or `Array<String>` of event names that trigger(s) the start of the composite event.
+**(Required)** A `string` name of an event or `string[]` of event names that trigger(s) the start of the composite event.
 
 > The handler for the composite event will receive the event object from the `triggerEvent`, if it exists.
 
@@ -81,7 +81,7 @@ The above call would make a parameterized composite event higher-order component
 
 ## `defaultDuration`
 
-**(Optional)** A `integer` of milliseconds indicating the default duration of time that the composite event should last. The higher-order component that `compose` returns takes an optional duration parameter. When that duration parameter is not specified or `undefined`, the `defaultDuration` is used. Using the [`withMouseRest` example](#withmouserest-example), if instead `EnhancedDiv` was created without specifying a duration like:
+**(Optional)** A `number` of milliseconds indicating the default duration of time that the composite event should last. The higher-order component that `compose` returns takes an optional duration parameter. When that duration parameter is not specified or `undefined`, the `defaultDuration` is used. Using the [`withMouseRest` example](#withmouserest-example), if instead `EnhancedDiv` was created without specifying a duration like:
 
 ```js
 const EnhancedDiv = withMouseRest()('div')
@@ -157,9 +157,11 @@ export default MyComponent extends PureComponent {
 
 ## `cancelEvent`
 
-**(Optional)** A `string` name of an event or `Array<String>` of event names that cancel(s) the timer started by [`triggerEvent`](#triggerevent) when a [`defaultDuration`](#defaultduration) is specified.
+**(Optional)** A `string` name of an event or `string[]` of event names that cancel(s) the timer started by [`triggerEvent`](#triggerevent) when a [`defaultDuration`](#defaultduration) is specified.
 
 If the `cancelEvent` occurs before the timer ends, the composite event is not completed and its handler will not be called. `cancelEvent` is ignored if [`defaultDuration`](#defaultduration) is unspecified.
+
+> If the `cancelEvent` matches an event passed to the enhanced component, it will be merged. For instance in the [`withMouseRest` example](#withmouserest-example), `onMouseOut` is one of the trigger events. If an `onMouseOut` handler was also passed to `<EnhancedDiv>` in addition `onMouseRest-500`, it will also be called.
 
 ## `shouldResetTimerOnRetrigger`
 

--- a/src/README.md
+++ b/src/README.md
@@ -169,7 +169,7 @@ If the `cancelEvent` occurs before the timer ends, the composite event is not co
 
 **(Optional)** A `boolean` specifying whether or not a [`triggerEvent`](#triggerevent) should reset the timer. If this optional configuration is not specified, then the value `true` will be used as the default.
 
-For the [`withMouseRest` example](#withmouserest-example), if another `onMouseOver` event happens after the initial one that began the composite event, the timer will be reset since `shouldResetTimerOnRetrigger` is `true`. This is because once the mouse starts moving, it's no longer at rest so the timer needs to be reset. If instead you were building a `mouseRemainOver` composite event where the mouse has to just remain over an element but can move around freely, `shouldResetTimerOnRetrigger` should be `false`. `onMouseMove` would trigger the composite event, and continuing to move shouldn't reset the timer. Additional `onMouseMove` events should just be ignored.
+For the [`withMouseRest` example](#withmouserest-example), if another `onMouseMove` event happens after the initial one that began the composite event, the timer will be reset since `shouldResetTimerOnRetrigger` is `true`. This is because once the mouse starts moving, it's no longer at rest so the timer needs to be reset. If instead you were building a `mouseRemainOver` composite event where the mouse has to just remain over an element but can move around freely, `shouldResetTimerOnRetrigger` should be `false`. `onMouseMove` would trigger the composite event, and continuing to move shouldn't reset the timer. Additional `onMouseMove` events should just be ignored.
 
 `shouldResetTimerOnRetrigger` is ignored if [`defaultDuration`](#defaultduration) is unspecified.
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export const compose = ({
   triggerEvent,
   defaultDuration = 0,
   cancelEvent,
-  // shouldResetTimerOnRetrigger = true,
+  shouldResetTimerOnRetrigger = true,
   // allowRefire = true,
   // beforeCallback,
 }) => {
@@ -86,16 +86,30 @@ export const compose = ({
           // If a specific handler was passed, call that one first
           this._callSpecificHandler(eventName, e)
 
+          // If no composite event handler was passed in, we can
+          // quit early
+          if (!onCompositeEvent) {
+            return
+          }
+
           // Call the composite event handler
-          if (onCompositeEvent) {
-            if (_isValidDuration(timeoutDuration)) {
+          if (_isValidDuration(timeoutDuration)) {
+            // If this is the first time the trigger event for the composite event
+            // has been called (i.e. no timeout) OR the shouldResetTimerOnRetrigger
+            // flag is on, we need to clear any existing timeout and start a fresh
+            // timer.
+            // In the case where the flag is off and we've got an active timer,
+            // we'll do nothing
+            if (!this._delayTimeout || shouldResetTimerOnRetrigger) {
+              clearTimeout(this._delayTimeout)
+
               this._delayTimeout = setTimeout(
                 () => onCompositeEvent(e),
                 timeoutDuration
               )
-            } else {
-              onCompositeEvent(e)
             }
+          } else {
+            onCompositeEvent(e)
           }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export const compose = ({
   defaultDuration = 0,
   cancelEvent,
   shouldResetTimerOnRetrigger = true,
-  // beforeCallback,
+  beforeHandle = () => true,
 }) => {
   if (!eventPropName) {
     throw new Error('`eventPropName` configuration must be specified')
@@ -86,7 +86,14 @@ export const compose = ({
         _callCompositeEvent = (e) => {
           let onCompositeEvent = this.props[compositeEventPropName]
 
-          onCompositeEvent(e)
+          // If a before handle function is defined, call it and check to see what the function returns
+          // truthy - means that it wants the HOC to to call the final handler with the event object
+          // falsy - means that it doesn't want the HOC to do anything
+          // The function receives the composite event handler + event object to make it's decision and
+          // can call the handler directly
+          if (beforeHandle(onCompositeEvent, e)) {
+            onCompositeEvent(e)
+          }
         }
 
         _handleTriggerEvent = (eventName, e) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,92 @@
-/* eslint-disable import/unambiguous */
+import React, {PureComponent} from 'react'
+import PropTypes from 'prop-types'
+import toLookup from 'array-to-lookup'
+import omit from 'lodash.omit'
 
-export const compose = () => null
+const _eventNamesToHandlerLookup = (eventNames, handler) =>
+  eventNames.reduce(
+    (lookup, eventName) => ({
+      ...lookup,
+      [eventName]: handler.bind(null, eventName),
+    }),
+    {}
+  )
+
+export const compose = ({
+  eventPropName,
+  triggerEvent,
+  // defaultDuration = 0,
+  cancelEvent,
+  // shouldResetTimerOnRetrigger = true,
+  // allowRefire = true,
+  // beforeCallback,
+}) => {
+  if (!eventPropName) {
+    throw new Error('`eventPropName` configuration must be specified')
+  }
+  if (!triggerEvent) {
+    throw new Error('`triggerEvent` configuration must be specified')
+  }
+
+  let triggerEvents = Array.isArray(triggerEvent)
+    ? triggerEvent
+    : [triggerEvent]
+  let cancelEvents = Array.isArray(cancelEvent) ? cancelEvent : [cancelEvent]
+
+  return (duration) => {
+    // if the duration is passed the composite even prop name needs to be parameterized
+    let compositeEventPropName =
+      eventPropName + (duration ? `-${duration}` : '')
+
+    return (Component) => {
+      let componentDisplayName =
+        Component.displayName || Component.name || 'Component'
+
+      return class extends PureComponent {
+        static displayName = `${componentDisplayName}WithCompositeEvent`
+
+        // Defining the known prop types that *could* be passed
+        // * the composite event (most likely)
+        // * an event matching the trigger events
+        // * an event matching the cancel events
+        static propTypes = {
+          ...toLookup(triggerEvents, PropTypes.func),
+          ...toLookup(cancelEvents, PropTypes.func),
+          [compositeEventPropName]: PropTypes.func,
+        }
+
+        _handleTriggerEvent = (eventName, e) => {
+          let onEvent = this.props[eventName]
+          let onCompositeEvent = this.props[compositeEventPropName]
+
+          // If a specific handler was passed, call that one first
+          if (onEvent) {
+            onEvent(e)
+          }
+
+          // Call the composite event handler
+          if (onCompositeEvent) {
+            onCompositeEvent(e)
+          }
+        }
+
+        render() {
+          // Want to pass all the props through to the underlying Component except the passed
+          // compositeEventPropName, which we need to handle specially.
+          // This will also include separate specific handlers matching trigger & cancel events
+          let passThruProps = omit(this.props, [compositeEventPropName])
+
+          // Create an object mapping of the trigger events to handlers.
+          // The handler needs to bind the trigger event name so that we can check to see if
+          // a specific handler was specify so we can fire that too
+          let triggerEventHandlers = _eventNamesToHandlerLookup(
+            triggerEvents,
+            this._handleTriggerEvent
+          )
+
+          return <Component {...passThruProps} {...triggerEventHandlers} />
+        }
+      }
+    }
+  }
+}

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -60,6 +60,16 @@ describe('compose', () => {
       expect(compositeEventHOC).not.toBeNull()
       expect(compositeEventHOC).toBeInstanceOf(Function)
     })
+
+    it('throws an error when no component is passed to the resultant HOC', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+      })
+
+      // throws an error because no Component was specified
+      expect(() => withCompositeEvent()()).toThrow()
+    })
   })
 
   describe('simple cases', () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -11,7 +11,6 @@ const withMouseRest = compose({
   defaultDuration: 150,
   cancelEvent: ['onMouseOut', 'onMouseDown'],
   shouldResetTimerOnRetrigger: true,
-  allowRefire: false,
 })
 
 const EnhancedSampleAnchor = withMouseRest()('a')
@@ -1489,8 +1488,6 @@ describe('compose', () => {
       expect(onCompositeEvent).toHaveBeenCalledTimes(3)
     })
   })
-
-  describe('`allowRefire` config', () => {})
 
   describe('`beforeCallback` config', () => {})
 })

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -78,10 +78,41 @@ describe('compose', () => {
       // 1. simulate mouse over
       anchorWrapper.simulate('mouseover')
 
-      // 2. simulate remaining over
+      // 2. simulate going over time
       jest.runTimersToTime(400)
 
       expect(onMouseRest).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels composite event on a wrapped DOM element', () => {
+      let onMouseRest = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSampleAnchor
+          href="http://www.benmvp.com/"
+          onMouseRest={onMouseRest}
+        />
+      )
+      let anchorWrapper = wrapper.find('a')
+
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 1. simulate mouse over
+      anchorWrapper.simulate('mouseover')
+
+      // 2. simulate some time passing
+      jest.runTimersToTime(100)
+
+      // shouldn't have been called yet because not enough time passed
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 3. simulate cancel event
+      anchorWrapper.simulate('mousedown')
+
+      // 2. simulate more time passing
+      jest.runTimersToTime(100)
+
+      // still shouldn't have been called because of the cancel
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
     })
 
     it('triggers composite event on a wrapped custom Component', () => {
@@ -94,10 +125,36 @@ describe('compose', () => {
       // 1. simulate mouse over
       dummyWrapper.prop('onMouseOver')()
 
-      // 2. simulate remaining over
+      // 2. simulate going over time
       jest.runTimersToTime(400)
 
       expect(onMouseRest).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels composite event on a wrapped custom Component', () => {
+      let onMouseRest = jest.fn()
+      let wrapper = shallow(<EnhancedSampleDummy onMouseRest={onMouseRest} />)
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 1. simulate mouse over
+      dummyWrapper.prop('onMouseOver')()
+
+      // 2. simulate some time passing
+      jest.runTimersToTime(100)
+
+      // shouldn't have been called yet because not enough time passed
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 3. simulate cancel event
+      dummyWrapper.prop('onMouseOut')()
+
+      // 2. simulate more time passing
+      jest.runTimersToTime(100)
+
+      // still shouldn't have been called because of the cancel
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -162,7 +219,7 @@ describe('compose', () => {
       expect(() => divWrapper.simulate('mousedown')).not.toThrow()
     })
 
-    it('does not blow up passing unsupported events', () => {
+    it('does not blow up passing unsupported events as triggers', () => {
       const withCompositeEvent = compose({
         eventPropName: 'onCompositeEvent',
         triggerEvent: ['onMouseDown', 'onPressIn'],
@@ -644,13 +701,482 @@ describe('compose', () => {
   })
 
   describe('`cancelEvent` config', () => {
-    // TODO: ensure specific handlers matching cancel events are also called
-    // TODO: no cancelEvent, 1 string, array of string
+    it('cancels composite event for a single string', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyTriggerEvent',
+        defaultDuration: 500,
+        cancelEvent: 'onDummyCancelEvent',
+      })
+      const EnhancedDummy = withCompositeEvent()(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      // simulate dummy trigger event
+      dummyWrapper.prop('onDummyTriggerEvent')()
+
+      jest.runTimersToTime(200)
+
+      // simulate dummy cancel event
+      dummyWrapper.prop('onDummyCancelEvent')()
+
+      jest.runTimersToTime(400)
+
+      // composite event shouldn't happen because of cancel
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('cancels composite event for multiple strings', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseUp',
+        defaultDuration: 350,
+        cancelEvent: ['onMouseDown', 'onMouseMove'],
+      })
+      const EnhancedDiv = withCompositeEvent()('div')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(<EnhancedDiv onCompositeEvent={onCompositeEvent} />)
+      let divWrapper = wrapper.find('div')
+
+      // simulate trigger event
+      divWrapper.simulate('mouseup')
+
+      jest.runTimersToTime(320)
+
+      // simulate a cancel event right before duration
+      divWrapper.simulate('mousedown')
+
+      // run past duration
+      jest.runTimersToTime(50)
+
+      // event was cancelled so shouldn't be called
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event again
+      divWrapper.simulate('mouseup')
+
+      // make sure composite event wasn't somehow called since previous time had ended
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(150)
+
+      // simulate other cancel event right before duration
+      divWrapper.simulate('mousemove')
+
+      // run past duration
+      jest.runTimersToTime(250)
+
+      // event was cancelled again so shouldn't be called
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not blow up passing unsupported events as cancel events', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onKeyUp',
+        defaultDuration: 900,
+        cancelEvent: ['onMouseDown', 'onPressOut'],
+      })
+      const EnhancedSection = withCompositeEvent()('section')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSection onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('section')
+
+      // simulate trigger event
+      sectionWrapper.simulate('onKeyUp')
+
+      // run some duration
+      jest.runTimersToTime(550)
+
+      // simulate supported cancel event
+      sectionWrapper.simulate('onMouseDown')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // run past duration
+      jest.runTimersToTime(550)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('calls composite event when non cancel event happens', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+        defaultDuration: 233,
+        cancelEvent: 'onMouseLeave',
+      })
+      const EnhancedLabel = withCompositeEvent()('label')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedLabel onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('label')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      sectionWrapper.simulate('mouseenter')
+
+      // run some duration
+      jest.runTimersToTime(198)
+
+      // simulate non cancel event
+      sectionWrapper.simulate('mouseout')
+
+      // run past duration
+      jest.runTimersToTime(198)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls composite event when cancel event happens after duration finishes (and does not blow up)', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+        defaultDuration: 654,
+        cancelEvent: 'onMouseLeave',
+      })
+      const EnhancedLabel = withCompositeEvent()('label')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedLabel onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('label')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      sectionWrapper.simulate('mouseenter')
+
+      // run past duration
+      jest.runTimersToTime(700)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // simulate non cancel event
+      expect(() => sectionWrapper.simulate('mouseleave')).not.toThrow()
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls composite event when cancel event happens w/o duration (and does not blow up)', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+        cancelEvent: 'onMouseLeave',
+      })
+      const EnhancedLabel = withCompositeEvent()('label')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedLabel onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('label')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      sectionWrapper.simulate('mouseenter')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // simulate non cancel event
+      expect(() => sectionWrapper.simulate('mouseleave')).not.toThrow()
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // run some duration
+      jest.runTimersToTime(700)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('also calls handler for event matching single `cancelEvent`', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+        defaultDuration: 482,
+        cancelEvent: 'onMouseLeave',
+      })
+      const EnhancedMain = withCompositeEvent()('main')
+
+      let onCompositeEvent = jest.fn()
+      let onMouseLeave = jest.fn()
+      let wrapper = shallow(
+        <EnhancedMain
+          onMouseLeave={onMouseLeave}
+          onCompositeEvent={onCompositeEvent}
+        />
+      )
+      let mainWrapper = wrapper.find('main')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onMouseLeave).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      mainWrapper.simulate('mouseenter')
+
+      jest.runTimersToTime(400)
+
+      // still neither should have been fired
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onMouseLeave).toHaveBeenCalledTimes(0)
+
+      // simulate cancel event
+      mainWrapper.simulate('mouseleave')
+
+      // specific handler should've been called with composite
+      // event cancelled
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onMouseLeave).toHaveBeenCalledTimes(1)
+
+      // run past duration
+      jest.runTimersToTime(100)
+
+      // no change expected
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onMouseLeave).toHaveBeenCalledTimes(1)
+    })
+
+    it('also calls handler for event matching one of events in `cancelEvent`', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseOver',
+        defaultDuration: 877,
+        cancelEvent: ['onClick', 'onKeyPress'],
+      })
+      const EnhancedSpan = withCompositeEvent()('span')
+
+      let onCompositeEvent = jest.fn()
+      let onKeyPress = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSpan
+          onKeyPress={onKeyPress}
+          onCompositeEvent={onCompositeEvent}
+        />
+      )
+      let spanWrapper = wrapper.find('span')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onKeyPress).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      spanWrapper.simulate('mouseover')
+
+      jest.runTimersToTime(400)
+
+      // still neither should have been fired
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onKeyPress).toHaveBeenCalledTimes(0)
+
+      // simulate cancel event
+      spanWrapper.simulate('keypress')
+
+      // specific handler should've been called with composite
+      // event cancelled
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onKeyPress).toHaveBeenCalledTimes(1)
+
+      // run past duration
+      jest.runTimersToTime(500)
+
+      // no change expected
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onKeyPress).toHaveBeenCalledTimes(1)
+    })
+
+    it('immediately cancels composite event when `triggerEvent` & `cancelEvent` match', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onKeyPress',
+        defaultDuration: 816,
+        cancelEvent: 'onKeyPress',
+      })
+      const EnhancedSpan = withCompositeEvent()('span')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSpan onCompositeEvent={onCompositeEvent} />
+      )
+      let spanWrapper = wrapper.find('span')
+
+      // simulate trigger/cancel event
+      // should immediately cancel
+      spanWrapper.simulate('keypress')
+
+      // immedately cancelled so shouldn't fire
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // run some time
+      jest.runTimersToTime(400)
+
+      // immedately cancelled so shouldn't fire
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate trigger/cancel event
+      // should immediately cancel
+      spanWrapper.simulate('keypress')
+
+      // immedately cancelled so shouldn't fire
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // run past first duration
+      jest.runTimersToTime(450)
+
+      // even though enough time passed for first one it was immediately cancelled
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // run past second duration
+      jest.runTimersToTime(450)
+
+      // even though enough time passed for second one it was immediately cancelled
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('cancels both composite events when there are 2 different ones with same `cancelEvent`', () => {
+      const withCompositeEventA = compose({
+        eventPropName: 'onCompositeEventA',
+        triggerEvent: 'onMouseOver',
+        defaultDuration: 400,
+        cancelEvent: 'onMouseOut',
+      })
+      const withCompositeEventB = compose({
+        eventPropName: 'onCompositeEventB',
+        triggerEvent: 'onMouseMove',
+        defaultDuration: 400,
+        cancelEvent: 'onMouseOut',
+      })
+      const EnhancedNav = withCompositeEventB()(withCompositeEventA()('nav'))
+
+      let onCompositeEventA = jest.fn()
+      let onCompositeEventB = jest.fn()
+      let wrapper = mount(
+        <EnhancedNav
+          onCompositeEventA={onCompositeEventA}
+          onCompositeEventB={onCompositeEventB}
+        />
+      )
+      let navWrapper = wrapper.find('nav')
+
+      // simulate trigger event A
+      navWrapper.simulate('mouseover')
+
+      // both handlers shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run some duration
+      jest.runTimersToTime(150)
+
+      // simulate trigger event B
+      navWrapper.simulate('mousemove')
+
+      // both handlers still shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run some more duration
+      jest.runTimersToTime(150)
+
+      // simulate common cancel event
+      navWrapper.simulate('mouseout')
+
+      // both handlers still shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run past duration A
+      jest.runTimersToTime(150)
+
+      // both handlers still shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run past duration B
+      jest.runTimersToTime(250)
+
+      // both handlers still shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+    })
+
+    it('calls appropariate composite event handlers even when `cancelEvent` of one matches trigger of another', () => {
+      const withCompositeEventA = compose({
+        eventPropName: 'onCompositeEventA',
+        triggerEvent: 'onMouseOver',
+        defaultDuration: 184,
+        cancelEvent: 'onKeyDown',
+      })
+      const withCompositeEventB = compose({
+        eventPropName: 'onCompositeEventB',
+        triggerEvent: 'onKeyDown',
+        defaultDuration: 748,
+        cancelEvent: 'onFocus',
+      })
+      const EnhancedNav = withCompositeEventB()(withCompositeEventA()('nav'))
+
+      let onCompositeEventA = jest.fn()
+      let onCompositeEventB = jest.fn()
+      let wrapper = mount(
+        <EnhancedNav
+          onCompositeEventA={onCompositeEventA}
+          onCompositeEventB={onCompositeEventB}
+        />
+      )
+      let navWrapper = wrapper.find('nav')
+
+      // simulate trigger event A
+      navWrapper.simulate('mouseover')
+
+      // both handlers shouldn't have been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run some duration
+      jest.runTimersToTime(150)
+
+      // both handlers still shouldn't have been called
+      // A hasn't had enough duration, B hasn't triggered
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // simulate cancel event A / trigger event B
+      navWrapper.simulate('keydown')
+
+      // both handlers still shouldn't have been called
+      // A was cancelled, B just started
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run past duration A
+      jest.runTimersToTime(500)
+
+      // both handlers still shouldn't have been called
+      // A still cancelled, B hasn't had enough duration
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // run past duration B
+      jest.runTimersToTime(300)
+
+      // As still cancelled, B did go past duration
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('`shouldResetTimerOnRetrigger` config', () => {})
-
-  describe('`defaultDuration` config', () => {})
 
   describe('`allowRefire` config', () => {})
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-empty-function */
 import React from 'react'
-import {shallow} from 'enzyme'
+import {shallow, mount} from 'enzyme'
 import {compose} from './'
 
 const Dummy = () => <div />
@@ -147,6 +147,21 @@ describe('compose', () => {
       expect(onCompositeEvent).toHaveBeenCalledTimes(2)
     })
 
+    it('does not blow up when composite event handler is not passed', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onMouseDown', 'onMouseUp'],
+      })
+      const EnhancedDiv = withCompositeEvent()('div')
+
+      let wrapper = shallow(<EnhancedDiv />)
+      let divWrapper = wrapper.find('div')
+
+      // verify that simulating trigger event even though composite even thandler
+      // wasn't passed doesn't blow up
+      expect(() => divWrapper.simulate('mousedown')).not.toThrow()
+    })
+
     it('does not blow up passing unsupported events', () => {
       const withCompositeEvent = compose({
         eventPropName: 'onCompositeEvent',
@@ -263,21 +278,374 @@ describe('compose', () => {
 
       expect(onCompositeEvent).toHaveBeenCalledTimes(0)
 
-      // 1. simulate trigger event
+      // simulate trigger event
       navWrapper.simulate('keydown', fakeEventObject)
 
       expect(onCompositeEvent).toHaveBeenCalledTimes(1)
       expect(onCompositeEvent).toHaveBeenCalledWith(fakeEventObject)
     })
+
+    it('calls 2 different composite event handlers that depend on same trigger event', () => {
+      const withCompositeEventA = compose({
+        eventPropName: 'onCompositeEventA',
+        triggerEvent: 'onMouseOver',
+      })
+      const withCompositeEventB = compose({
+        eventPropName: 'onCompositeEventB',
+        triggerEvent: 'onMouseOver',
+      })
+      const EnhancedNav = withCompositeEventB()(withCompositeEventA()('nav'))
+
+      let onCompositeEventA = jest.fn()
+      let onCompositeEventB = jest.fn()
+      let wrapper = mount(
+        <EnhancedNav
+          onCompositeEventA={onCompositeEventA}
+          onCompositeEventB={onCompositeEventB}
+        />
+      )
+      let navWrapper = wrapper.find('nav')
+
+      expect(onCompositeEventA).toHaveBeenCalledTimes(0)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      navWrapper.simulate('mouseover')
+
+      // both handlers should've been called
+      expect(onCompositeEventA).toHaveBeenCalledTimes(1)
+      expect(onCompositeEventB).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls generic handler when specifying duration override', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onKeyDown', 'onKeyUp'],
+      })
+      const EnhancedNav = withCompositeEvent(500)('nav')
+
+      let onCompositeEvent = jest.fn()
+      let onCompositeEvent500 = jest.fn()
+      let wrapper = shallow(
+        <EnhancedNav
+          onCompositeEvent={onCompositeEvent}
+          onCompositeEvent-500={onCompositeEvent500}
+        />
+      )
+      let navWrapper = wrapper.find('nav')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent500).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      navWrapper.simulate('keydown')
+
+      // should call the unparameterized version
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent500).toHaveBeenCalledTimes(0)
+
+      // fast forward to after the override duration
+      jest.runTimersToTime(600)
+
+      // still should only call unparameterized version
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent500).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('`defaultDuration` config', () => {
-    // TODO: test passing and not passing duration param
-    // TODO: ensure composite event doesn't get fired before time expires
+    it('calls composite event handler on specified default delay', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: 800,
+      })
+      const EnhancedDummy = withCompositeEvent()(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // still shouldn't be called because no time has passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(400)
+
+      // still shouldn't be called because delay hasn't fully passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(500)
+
+      // should've been called by now
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls paramterized composite event handler on specified delay override', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: 800,
+      })
+
+      // specify delay override
+      const EnhancedDummy = withCompositeEvent(300)(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent-300={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // still shouldn't be called because no time has passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(200)
+
+      // still shouldn't be called because delay hasn't fully passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(200)
+
+      // should've been called by now
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // fast forward past default duration time
+      jest.runTimersToTime(500)
+
+      // should not have been called again
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('immediately calls generic composite event handler with specified negative default delay', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: -800,
+      })
+      const EnhancedDummy = withCompositeEvent()(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // should be called immediately
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // run time passed absolute value
+      jest.runTimersToTime(825)
+
+      // still should've only been called once
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('still calls generic composite event handler after default duration when duration override is negative', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: 650,
+      })
+
+      // specify delay override
+      const EnhancedDummy = withCompositeEvent(-300)(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let onCompositeEvent300 = jest.fn()
+      let onCompositeEvent650 = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy
+          onCompositeEvent={onCompositeEvent}
+          onCompositeEvent-300={onCompositeEvent300}
+          onCompositeEvent-650={onCompositeEvent650}
+        />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent650).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // neither should be called yet
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent650).toHaveBeenCalledTimes(0)
+
+      // run time passed absolute value of duration override
+      jest.runTimersToTime(325)
+
+      // neither should still be called yet
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent650).toHaveBeenCalledTimes(0)
+
+      // run time passed default duration
+      jest.runTimersToTime(350)
+
+      // the generic composite event should be called now,
+      // but not the other ones
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent650).toHaveBeenCalledTimes(0)
+    })
+
+    it('still calls generic composite event handler on specified delay override when default duration is negative', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: -800,
+      })
+
+      // specify delay override
+      const EnhancedDummy = withCompositeEvent(300)(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let onCompositeEvent300 = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy
+          onCompositeEvent={onCompositeEvent}
+          onCompositeEvent-300={onCompositeEvent300}
+        />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // generic should be called immediately
+      // parameterized should never be called
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+
+      // run time passed absolute value of duration override
+      jest.runTimersToTime(325)
+
+      // still should've only been called once
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent300).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not call composite event handler with generic name with delay override', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: 800,
+      })
+
+      // specify delay override
+      const EnhancedDummy = withCompositeEvent(500)(Dummy)
+
+      let onCompositeEvent = jest.fn()
+
+      // use generic name instead of expected parameterized name
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      //  shouldn't have been called because no time has passed anyway
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(350)
+
+      // still shouldn't be called because delay hasn't fully passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(200)
+
+      // still not called because used the generic name
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('calls multiple composite event handlers with different duration overrides at the right time', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+        defaultDuration: 800,
+      })
+
+      // add multiple composite events
+      const EnhancedDummy = withCompositeEvent(1000)(
+        withCompositeEvent(450)(withCompositeEvent()(Dummy))
+      )
+
+      let onCompositeEvent = jest.fn()
+      let onCompositeEvent450 = jest.fn()
+      let onCompositeEvent1000 = jest.fn()
+      let wrapper = mount(
+        <EnhancedDummy
+          onCompositeEvent={onCompositeEvent}
+          onCompositeEvent-450={onCompositeEvent450}
+          onCompositeEvent-1000={onCompositeEvent1000}
+        />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      // obviously not called after
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      // still shouldn't be called because no time has passed
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent450).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent1000).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(500)
+
+      // 450 version should've been called but not others
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onCompositeEvent450).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent1000).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(400)
+
+      // 450 version + default should've been called now
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent450).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent1000).toHaveBeenCalledTimes(0)
+
+      jest.runTimersToTime(200)
+
+      // all should've been called now
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent450).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent1000).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('`cancelEvent` config', () => {
     // TODO: ensure specific handlers matching cancel events are also called
+    // TODO: no cancelEvent, 1 string, array of string
   })
 
   describe('`shouldResetTimerOnRetrigger` config', () => {})

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,7 +1,290 @@
+/* eslint-disable no-empty-function */
+import React from 'react'
+import {shallow} from 'enzyme'
 import {compose} from './'
 
+const Dummy = () => <div />
+
+const withMouseRest = compose({
+  eventPropName: 'onMouseRest',
+  triggerEvent: ['onMouseOver', 'onMouseMove'],
+  defaultDuration: 150,
+  cancelEvent: ['onMouseOut', 'onMouseDown'],
+  shouldResetTimerOnRetrigger: true,
+  allowRefire: false,
+})
+
+const EnhancedSampleAnchor = withMouseRest()('a')
+const EnhancedSampleDummy = withMouseRest()(Dummy)
+
+jest.useFakeTimers()
+
 describe('compose', () => {
-  it('returns null', () => {
-    expect(compose()).toBe(null)
+  describe('error handling', () => {
+    it('throws an error if no configuration object is specified', () => {
+      expect(() => compose()).toThrow()
+    })
+
+    it('throws an error if no configurations are specified', () => {
+      expect(() => compose({})).toThrow()
+    })
+
+    it('throws an error if no `triggerEvent` is specified when `eventPropName` is', () => {
+      expect(() =>
+        compose({
+          eventPropName: 'compositeEvent',
+        })
+      ).toThrow()
+    })
+
+    it('throws an error if no `eventPropName` is specified when `triggerEvent` is', () => {
+      expect(() =>
+        compose({
+          triggerEvent: 'onClick',
+        })
+      ).toThrow()
+    })
+
+    it('does not throw an error when `eventPropName` & `triggerEvent` configurations are specified', () => {
+      let getCompositeEventHOC = () =>
+        compose({
+          eventPropName: 'compositeEvent',
+          triggerEvent: 'onClick',
+        })
+
+      expect(getCompositeEventHOC).not.toThrow()
+
+      let compositeEventHOC = getCompositeEventHOC()
+
+      expect(compositeEventHOC).toBeDefined()
+      expect(compositeEventHOC).not.toBeNull()
+      expect(compositeEventHOC).toBeInstanceOf(Function)
+    })
   })
+
+  describe('simple cases', () => {
+    it('triggers composite event on a wrapped DOM element', () => {
+      let onMouseRest = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSampleAnchor
+          href="http://www.benmvp.com/"
+          onMouseRest={onMouseRest}
+        />
+      )
+      let anchorWrapper = wrapper.find('a')
+
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 1. simulate mouse over
+      anchorWrapper.simulate('mouseover')
+
+      // 2. simulate remaining over
+      jest.runTimersToTime(400)
+
+      expect(onMouseRest).toHaveBeenCalledTimes(1)
+    })
+
+    it('triggers composite event on a wrapped custom Component', () => {
+      let onMouseRest = jest.fn()
+      let wrapper = shallow(<EnhancedSampleDummy onMouseRest={onMouseRest} />)
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+      // 1. simulate mouse over
+      dummyWrapper.prop('onMouseOver')()
+
+      // 2. simulate remaining over
+      jest.runTimersToTime(400)
+
+      expect(onMouseRest).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('`triggerEvent` config', () => {
+    it('triggers composite event for a single string', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onDummyEvent',
+      })
+      const EnhancedDummy = withCompositeEvent()(Dummy)
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedDummy onCompositeEvent={onCompositeEvent} />
+      )
+      let dummyWrapper = wrapper.find(Dummy)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate dummy event
+      dummyWrapper.prop('onDummyEvent')()
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('triggers composite event for multiple strings', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onMouseDown', 'onMouseUp'],
+      })
+      const EnhancedDiv = withCompositeEvent()('div')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(<EnhancedDiv onCompositeEvent={onCompositeEvent} />)
+      let divWrapper = wrapper.find('div')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // first simulate first trigger event
+      divWrapper.simulate('mousedown')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+
+      // second simulate second trigger event
+      divWrapper.simulate('mouseup')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not blow up passing unsupported events', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onMouseDown', 'onPressIn'],
+      })
+      const EnhancedSection = withCompositeEvent()('section')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSection onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('section')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate supported trigger event
+      sectionWrapper.simulate('mousedown')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not trigger composite event when non trigger event happens', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+      })
+      const EnhancedLabel = withCompositeEvent()('label')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(
+        <EnhancedLabel onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('label')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // simulate non trigger event
+      sectionWrapper.simulate('mousedown')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+    })
+
+    it('also calls handler for event matching single `triggerEvent`', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: 'onMouseEnter',
+      })
+      const EnhancedMain = withCompositeEvent()('main')
+
+      let onCompositeEvent = jest.fn()
+      let onMouseEnter = jest.fn()
+      let wrapper = shallow(
+        <EnhancedMain
+          onMouseEnter={onMouseEnter}
+          onCompositeEvent={onCompositeEvent}
+        />
+      )
+      let sectionWrapper = wrapper.find('main')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onMouseEnter).toHaveBeenCalledTimes(0)
+
+      // simulate trigger event
+      sectionWrapper.simulate('mouseenter')
+
+      // verify both the vanilla & composite events are fired
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onMouseEnter).toHaveBeenCalledTimes(1)
+    })
+
+    it('also calls handler for event matching one of events in `triggerEvent`', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onClick', 'onKeyPress'],
+      })
+      const EnhancedSpan = withCompositeEvent()('span')
+
+      let onCompositeEvent = jest.fn()
+      let onClick = jest.fn()
+      let wrapper = shallow(
+        <EnhancedSpan onClick={onClick} onCompositeEvent={onCompositeEvent} />
+      )
+      let sectionWrapper = wrapper.find('span')
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+      expect(onClick).toHaveBeenCalledTimes(0)
+
+      // simulate supported trigger event
+      sectionWrapper.simulate('click')
+
+      // verify both the vanilla & composite events are fired
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onClick).toHaveBeenCalledTimes(1)
+
+      // simulate other trigger event
+      sectionWrapper.simulate('keypress')
+
+      // verify composite event gets triggered again but not vanilla event
+      expect(onCompositeEvent).toHaveBeenCalledTimes(2)
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes event object to composite event handler', () => {
+      const withCompositeEvent = compose({
+        eventPropName: 'onCompositeEvent',
+        triggerEvent: ['onKeyDown', 'onKeyUp'],
+      })
+      const EnhancedNav = withCompositeEvent()('nav')
+
+      let onCompositeEvent = jest.fn()
+      let wrapper = shallow(<EnhancedNav onCompositeEvent={onCompositeEvent} />)
+      let navWrapper = wrapper.find('nav')
+      let fakeEventObject = {}
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // 1. simulate trigger event
+      navWrapper.simulate('keydown', fakeEventObject)
+
+      expect(onCompositeEvent).toHaveBeenCalledTimes(1)
+      expect(onCompositeEvent).toHaveBeenCalledWith(fakeEventObject)
+    })
+  })
+
+  describe('`defaultDuration` config', () => {
+    // TODO: test passing and not passing duration param
+    // TODO: ensure composite event doesn't get fired before time expires
+  })
+
+  describe('`cancelEvent` config', () => {
+    // TODO: ensure specific handlers matching cancel events are also called
+  })
+
+  describe('`shouldResetTimerOnRetrigger` config', () => {})
+
+  describe('`defaultDuration` config', () => {})
+
+  describe('`allowRefire` config', () => {})
+
+  describe('`beforeCallback` config', () => {})
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/react@^15.0.22":
+  version "15.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.39.tgz#5a820c75cabf4cbfa177a3ab5a9a0634c46b14d1"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -139,6 +143,10 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
+
+array-to-lookup@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-to-lookup/-/array-to-lookup-1.0.1.tgz#158b821b5fdbeaa1eaf32178db8416d83046dd7b"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -437,6 +445,14 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -449,17 +465,38 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
 
-babel-plugin-transform-async-to-generator@^6.22.0:
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-to-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
   dependencies:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -629,7 +666,7 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
-babel-plugin-transform-exponentiation-operator@^6.22.0:
+babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-exponentiation-operator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
   dependencies:
@@ -642,6 +679,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
@@ -750,6 +794,16 @@ babel-preset-react@^6.24.1:
     babel-plugin-transform-react-jsx-self "^6.22.0"
     babel-plugin-transform-react-jsx-source "^6.22.0"
     babel-preset-flow "^6.23.0"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
 
 babel-register@^6.24.1:
   version "6.24.1"
@@ -1187,6 +1241,12 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-equal-ident@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz#06f4b89e53710cd6cea4a7781c7a956642de8dc9"
+  dependencies:
+    lodash.isequal "^3.0"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -1311,6 +1371,24 @@ encoding@^0.1.11:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme-matchers@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/enzyme-matchers/-/enzyme-matchers-3.6.1.tgz#bade39bc6631f695df1f346365373df56bfa8b4a"
+  dependencies:
+    deep-equal-ident "^1.1.1"
+
+enzyme-to-json@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz#e34f4d126bb3f4696ce3800b51f9ed83df708799"
+  dependencies:
+    lodash.filter "^4.6.0"
+    lodash.isnil "^4.0.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.omitby "^4.5.0"
+    lodash.range "^3.2.0"
+    object-values "^1.0.0"
+    object.entries "^1.0.3"
 
 enzyme@^2.9.1:
   version "2.9.1"
@@ -2384,6 +2462,14 @@ jest-environment-node@^20.0.3:
     jest-mock "^20.0.3"
     jest-util "^20.0.3"
 
+jest-enzyme@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/jest-enzyme/-/jest-enzyme-3.6.1.tgz#37f4c6183aeb4d34ef383d28bba6fe8b0bff5125"
+  dependencies:
+    "@types/react" "^15.0.22"
+    enzyme-matchers "^3.6.1"
+    enzyme-to-json "^1.5.0"
+
 jest-haste-map@^20.0.4:
   version "20.0.4"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.4.tgz#653eb55c889ce3c021f7b94693f20a4159badf03"
@@ -2726,6 +2812,22 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash._baseisequal@^3.0.0:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
+  dependencies:
+    lodash.isarray "^3.0.0"
+    lodash.istypedarray "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._bindcallback@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -2746,7 +2848,7 @@ lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.filter@^4.4.0:
+lodash.filter@^4.4.0, lodash.filter@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 
@@ -2757,6 +2859,41 @@ lodash.flatten@^4.2.0:
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^3.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-3.0.4.tgz#1c35eb3b6ef0cd1ff51743e3ea3cf7fdffdacb64"
+  dependencies:
+    lodash._baseisequal "^3.0.0"
+    lodash._bindcallback "^3.0.0"
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.istypedarray@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.map@^4.4.0:
   version "4.6.0"
@@ -2770,9 +2907,21 @@ lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
+lodash.omitby@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
+
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -3054,6 +3203,10 @@ object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
+
 object.assign@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
@@ -3062,7 +3215,7 @@ object.assign@^4.0.4:
     function-bind "^1.1.0"
     object-keys "^1.0.10"
 
-object.entries@^1.0.4:
+object.entries@^1.0.3, object.entries@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
   dependencies:


### PR DESCRIPTION
Implemented base `compose` function using TDD approach. Wrote tests for each configuration and then did the implementation. Ended up getting rid of the `allowRefire` config and renamed `beforeCallback` to `beforeHandle`. The `allowRefire` config isn't needed because we'll allow a composite event to refire w/o a cancel event happening.

Also updated the docs for `compose` as well as the general README. Finally, updated `.travis.yml` so that we run tests against multiple Node instances >= 4.