### PR TITLE
build: Use Rollup to generate UMD bundles

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,8 +14,8 @@ coverage
 # Build scripts
 gulpfile.js
 
-# Test files
-src/*.spec.js
+# All source files
+src
 
-# scripts
+# All script files
 _scripts

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,11 +8,23 @@ const sourcemaps = require('gulp-sourcemaps')
 const replace = require('gulp-replace')
 const debug = require('gulp-debug')
 const util = require('gulp-util')
+
 const del = require('del')
+
+const {rollup} = require('rollup')
+const rollupBabel = require('rollup-plugin-babel')
+const rollupNodeResolve = require('rollup-plugin-node-resolve')
+const rollupCommonjs = require('rollup-plugin-commonjs')
+const rollupReplace = require('rollup-plugin-replace')
+const rollupUglify = require('rollup-plugin-uglify')
 
 const FORMAT_ESM = 'esm'
 const FORMAT_CJS = 'cjs'
 const FORMAT_UMD = 'umd'
+
+const MODULE_NAME = 'RCE'
+
+const SOURCE_ENTRY = 'src/index.js'
 
 const FILES_TO_BUILD = [
   // include all the JavaScript files in src/ directory
@@ -33,19 +45,30 @@ const UMD_TRANSFORM_PLUGIN = [
   {
     globals: {
       react: 'React',
-      index: 'RCE',
-      compose: 'RCE_compose',
-      generic: 'RCE_generic',
-      mouse: 'RCE_mouse',
-      key: 'RCE_key',
-      './compose': 'RCE_compose',
-      './generic': 'RCE_generic',
-      './mouse': 'RCE_mouse',
-      './key': 'RCE_key',
+      index: MODULE_NAME,
+      compose: `${MODULE_NAME}_compose`,
+      generic: `${MODULE_NAME}_generic`,
+      mouse: `${MODULE_NAME}_mouse`,
+      key: `${MODULE_NAME}_key`,
+      './compose': `${MODULE_NAME}_compose`,
+      './generic': `${MODULE_NAME}_generic`,
+      './mouse': `${MODULE_NAME}_mouse`,
+      './key': `${MODULE_NAME}_key`,
     },
     exactGlobals: true,
   },
 ]
+
+const _getBabelConfig = (format) => ({
+  babelrc: false,
+
+  presets: [format === FORMAT_ESM ? ESM_ENV_PRESET : 'env', 'stage-3', 'react'],
+  plugins: [
+    'transform-class-properties',
+    'external-helpers',
+    ...(format === FORMAT_UMD ? [UMD_TRANSFORM_PLUGIN] : []),
+  ],
+})
 
 const _getBabelStream = (format) =>
   gulp
@@ -54,45 +77,100 @@ const _getBabelStream = (format) =>
     // initialize the sourcemaps (used by UMD only)
     .pipe(format === FORMAT_UMD ? sourcemaps.init() : util.noop())
     // do the appropriate babel transpile (this is a copy from package.json)
-    .pipe(
-      babel({
-        babelrc: false,
+    .pipe(babel(_getBabelConfig(format)))
 
-        presets: [
-          format === FORMAT_ESM ? ESM_ENV_PRESET : 'env',
-          'stage-3',
-          'react',
-        ],
-        plugins: [
-          'transform-class-properties',
-          'external-helpers',
-          ...(format === FORMAT_UMD ? [UMD_TRANSFORM_PLUGIN] : []),
-        ],
-      })
-    )
+const _genRollupDist = (minify = false) =>
+  rollup({
+    entry: SOURCE_ENTRY,
 
-gulp.task('build:clean:cjs', () => del(['lib/cjs']))
-gulp.task('build:clean:esm', () => del(['lib/esm']))
-gulp.task('build:clean:umd', () => del(['lib/umd']))
+    // exclude React dependency from bundle
+    external: ['react'],
+
+    plugins: [
+      // Need to replace `process.env.NODE_ENV` in the bundle because most likely the place where this
+      // would be used doesn't support it. When minified we assume production, dev otherwise
+      rollupReplace({
+        'process.env.NODE_ENV': JSON.stringify(
+          minify ? 'production' : 'development'
+        ),
+      }),
+
+      // Locate modules using the Node resolution algorithm, for using third party modules in node_modules
+      rollupNodeResolve({
+        // use "module" field for ES6 module if possible
+        module: true,
+
+        // use (legacy) "jsnext:main" if possible
+        jsnext: true,
+
+        // use "main" field or index.js
+        main: true,
+      }),
+
+      // Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
+      rollupCommonjs({
+        // Node modules are the ones we're trying to get it to understand
+        include: 'node_modules/**',
+      }),
+
+      // Seamless integration between Rollup and Babel
+      rollupBabel(
+        Object.assign(
+          {
+            // don't worry about transpiling node_modules when bundling
+            exclude: 'node_modules/**',
+
+            // don't place helpers at the top of the files, but point to reference contained external helpers
+            externalHelpers: true,
+          },
+          _getBabelConfig(FORMAT_ESM)
+        )
+      ),
+
+      // Minify the code if that option is specified
+      minify ? rollupUglify() : null,
+    ].filter(Boolean),
+  }).then((bundle) =>
+    bundle.write({
+      format: FORMAT_UMD,
+      dest: `dist/react-composite-events${minify ? '.min' : ''}.js`,
+
+      // The name to use for UMD bundle
+      moduleName: MODULE_NAME,
+
+      // Mapping of imported modules to globally accessible names for UMD bundle
+      globals: {
+        react: 'React',
+      },
+
+      sourceMap: true,
+    })
+  )
+
+gulp.task('build:clean:lib:cjs', () => del(['lib/cjs']))
+gulp.task('build:clean:lib:esm', () => del(['lib/esm']))
+gulp.task('build:clean:lib:umd', () => del(['lib/umd']))
+gulp.task('build:clean:dist', () => del(['dist/umd']))
 gulp.task('build:clean', [
-  'build:clean:cjs',
-  'build:clean:esm',
-  'build:clean:umd',
+  'build:clean:lib:cjs',
+  'build:clean:lib:esm',
+  'build:clean:lib:umd',
+  'build:clean:dist',
 ])
 
-gulp.task('build:cjs', ['build:clean:cjs'], () =>
+gulp.task('build:lib:cjs', ['build:clean:lib:cjs'], () =>
   _getBabelStream(FORMAT_CJS)
     .pipe(debug({title: 'Building CJS'}))
     .pipe(gulp.dest('lib/cjs'))
 )
 
-gulp.task('build:esm', ['build:clean:esm'], () =>
+gulp.task('build:lib:esm', ['build:clean:lib:esm'], () =>
   _getBabelStream(FORMAT_ESM)
     .pipe(debug({title: 'Building ESM:'}))
     .pipe(gulp.dest('lib/esm'))
 )
 
-gulp.task('build:umd', ['build:clean:umd'], () =>
+gulp.task('build:lib:umd', ['build:clean:lib:umd'], () =>
   _getBabelStream(FORMAT_UMD)
     // If you're using UMD, you probably don't have `process.env.NODE_ENV` so, we'll replace
     // it. If you're using the unimified UMD, you're probably in DEV
@@ -102,7 +180,7 @@ gulp.task('build:umd', ['build:clean:umd'], () =>
     .pipe(gulp.dest('lib/umd'))
 )
 
-gulp.task('build:umd:min', ['build:clean:umd'], () =>
+gulp.task('build:lib:umd:min', ['build:clean:lib:umd'], () =>
   _getBabelStream(FORMAT_UMD)
     // If you're using UMD, you probably don't have `process.env.NODE_ENV` so, we'll replace
     // it. If you're using the imified UMD, you're probably in production
@@ -115,6 +193,17 @@ gulp.task('build:umd:min', ['build:clean:umd'], () =>
     .pipe(gulp.dest('lib/umd'))
 )
 
-gulp.task('build', ['build:cjs', 'build:esm', 'build:umd', 'build:umd:min'])
+gulp.task('build:dist', ['build:clean:dist'], () => _genRollupDist())
+
+gulp.task('build:dist:min', ['build:clean:dist'], () => _genRollupDist(true))
+
+gulp.task('build', [
+  'build:lib:cjs',
+  'build:lib:esm',
+  'build:lib:umd',
+  'build:lib:umd:min',
+  'build:dist',
+  'build:dist:min',
+])
 
 gulp.task('default', ['build'])

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "jsnext:main": "lib/esm/index.js",
-  "browser": "lib/umd/index.js",
+  "browser": "dist/react-composite-events.js",
   "keywords": [
     "react",
     "react-native",
@@ -103,7 +103,13 @@
     "prettier-eslint-cli": "^4.1.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^15.6.1",
+    "rollup": "^0.45.2",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-commonjs": "^8.1.0",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^1.1.1",
+    "rollup-plugin-uglify": "^2.0.1"
   },
   "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.X, acorn@^4.0.4:
+acorn@4.X, acorn@^4.0.1, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
@@ -287,7 +287,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.0.2, babel-core@^6.24.1:
+babel-core@6, babel-core@^6.0.0, babel-core@^6.0.2, babel-core@^6.24.1:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -559,7 +559,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -957,7 +957,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-browser-resolve@^1.11.2:
+browser-resolve@^1.11.0, browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
   dependencies:
@@ -982,7 +982,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1788,6 +1788,14 @@ estraverse@^1.9.1:
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -2639,6 +2647,10 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
 
 is-my-json-valid@^2.10.0:
   version "2.16.0"
@@ -3552,6 +3564,18 @@ lru-queue@0.1:
   resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
   dependencies:
     es5-ext "~0.10.2"
+
+magic-string@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.15.2.tgz#0681d7388741bbc3addaa65060992624c6c09e9c"
+  dependencies:
+    vlq "^0.2.1"
+
+magic-string@^0.19.0:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.1.tgz#14d768013caf2ec8fdea16a49af82fc377e75201"
+  dependencies:
+    vlq "^0.2.1"
 
 make-error-cause@^1.1.1:
   version "1.2.2"
@@ -4519,6 +4543,68 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rollup-plugin-babel@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz#16528197b0f938a1536f44683c7a93d573182f57"
+  dependencies:
+    babel-core "6"
+    babel-plugin-transform-es2015-classes "^6.9.0"
+    object-assign "^4.1.0"
+    rollup-pluginutils "^1.5.0"
+
+rollup-plugin-commonjs@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.1.0.tgz#8ac9a87e6ea4c0d136e3e0e25ef41058957622b0"
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-plugin-replace@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz#396315ded050a6ce43b9518a886a3f60efb1ea33"
+  dependencies:
+    magic-string "^0.15.2"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^1.5.0"
+
+rollup-plugin-uglify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz#67b37ad1efdafbd83af4c36b40c189ee4866c969"
+  dependencies:
+    uglify-js "^3.0.9"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup@^0.45.2:
+  version "0.45.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.45.2.tgz#63a284c2b31234656f24e9e9717fabb6a7f0fa43"
+  dependencies:
+    source-map-support "^0.4.0"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -4632,7 +4718,7 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:
@@ -4966,7 +5052,7 @@ uglify-js@^2.6:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
-uglify-js@^3.0.5:
+uglify-js@^3.0.5, uglify-js@^3.0.9:
   version "3.0.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.27.tgz#a97db8c8ba6b9dba4e2f88d86aa9548fa6320034"
   dependencies:
@@ -5071,6 +5157,10 @@ vinyl@^0.5.0:
     clone "^1.0.0"
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
+
+vlq@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
In addition to having lib formats (ESM, CJS & UMD), we should also have a bundled dist in UMD for those clients that basically can't do anything. The dist can be used directly in a `<script>` or used in a legacy module system like requireJS. There's a minified production bundle as well as an uniminified development bundle. Both have sourcemaps.

Basically had to duplicate all of the configuration for both gulp & rollup, but with shared objects things remained DRY.

Also excluded the `src/` directory