### PR TITLE
feat(API): Implement mouse-remain HOCs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export {default as compose} from './compose'
 export * from './generic'
+export * from './mouse'

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -1,0 +1,25 @@
+import compose from './compose'
+
+export const withMouseRest = compose({
+  eventPropName: 'onMouseRest',
+  triggerEvent: ['onMouseOver', 'onMouseMove'],
+  defaultDuration: 500,
+  cancelEvent: ['onMouseOut', 'onMouseDown'],
+})
+
+export const withMouseRemainOver = compose({
+  eventPropName: 'onMouseRemainOver',
+  triggerEvent: ['onMouseOver', 'onMouseMove'],
+  defaultDuration: 500,
+  // including `onMouseDown` because clicking is basically a different action
+  cancelEvent: ['onMouseOut', 'onMouseDown'],
+  // as long as the mouse is over, moving around doesn't matter
+  shouldResetTimerOnRetrigger: false,
+})
+
+export const withMouseRemainOut = compose({
+  eventPropName: 'onMouseRemainOut',
+  triggerEvent: 'onMouseOut',
+  defaultDuration: 500,
+  cancelEvent: 'onMouseOver',
+})

--- a/src/mouse.md
+++ b/src/mouse.md
@@ -6,8 +6,8 @@ The following collection of APIs apply primarily to components that handle mouse
 
 - [Higher-order components](#higher-order-components)
   - [`withMouseRest()`](#withmouserest)
-  - [`withMouseRemainOver()`](#withmouseremainover)
   - [`withMouseRemainOut()`](#withmouseremainout)
+  - [`withMouseRemainOver()`](#withmouseremainover)
   - [`withMouseEnterLeft()`](#withmouseenterleft)
   - [`withMouseEnterRight()`](#withmouseenterright)
   - [`withMouseEnterTop()`](#withmouseentertop)
@@ -84,64 +84,6 @@ See related [`withMouseRemainOver()`](#withmouseremainover).
 
 
 
-### `withMouseRemainOver()`
-
-```js
-withMouseRemainOver
-  duration: integer = 500
-): HigherOrderComponent
-```
-
-Creates an HOC for a composite event (named `onMouseRemainOver-*`) that is triggered when the user mouses over a component and doesn't mouse out of that component or mouse down on it for a specified duration of time. The user can continue to move the mouse over the component to trigger `onMouseRemainOver`.
-
-```js
-import {withMouseRemainOver} from 'react-composite-events'
-// or
-import {withMouseRemainOver} from 'react-composite-events/mouse'
-
-const EnhancedDiv = withMouseRemainOver(450)('div')
-
-export default MyComponent extends PureComponent {
-  _handleMouseRemainOver() {
-    console.log(`450ms with mouse remaining over`);
-  }
-
-  render() {
-    return (
-      <EnhancedDiv onMouseRemainOver-450={this._handleMouseRemainOver.bind(this)} />
-    )
-  }
-}
-```
-
-When no `duration` parameter is specified, then the value for this parameter is defaulted to `500` (500 milliseconds). In this case the composite event prop is simply `onMouseRemainOver`.
-
-```js
-import {withMouseRemainOver} from 'react-composite-events'
-// or
-import {withMouseRemainOver} from 'react-composite-events/mouse'
-
-const EnhancedDiv = withMouseRemainOver()('div')
-
-export default MyComponent extends PureComponent {
-  _handleMouseRemainOver() {
-    console.log(`default mouse remain over!`);
-  }
-
-  render() {
-    return (
-      <EnhancedDiv onMouseRemainOver={this._handleMouseRemainOver.bind(this)} />
-    )
-  }
-}
-```
-
-> `withMouseRemainOver` adds handlers for `onMouseOver`, `onMouseMove`, `onMouseOut` & `onMouseDown` to build the `onMouseRemainOver` composite event. The handler for `onMouseRemainOver` will receive the event object for either `onMouseOver` or `onMouseMove`, if it exists.
-
-See related [`withMouseRest()`](#withmouserest) & [`withMouseRemainOut()`](#withmouseremainout).
-
-
-
 ### `withMouseRemainOut()`
 
 ```js
@@ -197,6 +139,64 @@ export default MyComponent extends PureComponent {
 > `withMouseRemainOut` adds handlers for `onMouseOut` & `onMouseOver` to build the `onMouseRemainOut` composite event. The handler for `onMouseRemainOut` will receive the event object for `onMouseOut`, if it exists.
 
 See related [`withMouseRemainOver()`](#withmouseremainover).
+
+
+
+### `withMouseRemainOver()`
+
+```js
+withMouseRemainOver
+  duration: integer = 500
+): HigherOrderComponent
+```
+
+Creates an HOC for a composite event (named `onMouseRemainOver-*`) that is triggered when the user mouses over a component and doesn't mouse out of that component or mouse down on it for a specified duration of time. The user can continue to move the mouse over the component to trigger `onMouseRemainOver`.
+
+```js
+import {withMouseRemainOver} from 'react-composite-events'
+// or
+import {withMouseRemainOver} from 'react-composite-events/mouse'
+
+const EnhancedDiv = withMouseRemainOver(450)('div')
+
+export default MyComponent extends PureComponent {
+  _handleMouseRemainOver() {
+    console.log(`450ms with mouse remaining over`);
+  }
+
+  render() {
+    return (
+      <EnhancedDiv onMouseRemainOver-450={this._handleMouseRemainOver.bind(this)} />
+    )
+  }
+}
+```
+
+When no `duration` parameter is specified, then the value for this parameter is defaulted to `500` (500 milliseconds). In this case the composite event prop is simply `onMouseRemainOver`.
+
+```js
+import {withMouseRemainOver} from 'react-composite-events'
+// or
+import {withMouseRemainOver} from 'react-composite-events/mouse'
+
+const EnhancedDiv = withMouseRemainOver()('div')
+
+export default MyComponent extends PureComponent {
+  _handleMouseRemainOver() {
+    console.log(`default mouse remain over!`);
+  }
+
+  render() {
+    return (
+      <EnhancedDiv onMouseRemainOver={this._handleMouseRemainOver.bind(this)} />
+    )
+  }
+}
+```
+
+> `withMouseRemainOver` adds handlers for `onMouseOver`, `onMouseMove`, `onMouseOut` & `onMouseDown` to build the `onMouseRemainOver` composite event. The handler for `onMouseRemainOver` will receive the event object for either `onMouseOver` or `onMouseMove`, if it exists.
+
+See related [`withMouseRest()`](#withmouserest) & [`withMouseRemainOut()`](#withmouseremainout).
 
 
 

--- a/src/mouse.spec.js
+++ b/src/mouse.spec.js
@@ -1,0 +1,441 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+import {withMouseRest, withMouseRemainOut, withMouseRemainOver} from './mouse'
+
+jest.useFakeTimers()
+
+describe('`withMouseRest`', () => {
+  it('calls handler after mouse over & default 500 ms', () => {
+    const EnhancedAnchor = withMouseRest()('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor href="http://www.benmvp.com/" onMouseRest={onMouseRest} />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(500)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse move & default 500 ms', () => {
+    const EnhancedAnchor = withMouseRest()('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor href="http://www.benmvp.com/" onMouseRest={onMouseRest} />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(500)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse over & specified duration', () => {
+    const EnhancedAnchor = withMouseRest(450)('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRest-450={onMouseRest}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(450)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse move & specified duration', () => {
+    const EnhancedAnchor = withMouseRest(450)('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRest-450={onMouseRest}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(450)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call handler if mouse out happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRest()('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor href="http://www.benmvp.com/" onMouseRest={onMouseRest} />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate cancel event
+    anchorWrapper.simulate('mouseout')
+
+    // 4. simulate going over time
+    jest.runTimersToTime(350)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler if mouse down happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRest()('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor href="http://www.benmvp.com/" onMouseRest={onMouseRest} />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate cancel event
+    anchorWrapper.simulate('mousedown')
+
+    // 4. simulate going over time
+    jest.runTimersToTime(350)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+  })
+
+  it('delays calling handler if trigger event happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRest()('a')
+
+    let onMouseRest = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor href="http://www.benmvp.com/" onMouseRest={onMouseRest} />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate trigger again before time has expired
+    anchorWrapper.simulate('mousemove')
+
+    // 4. simulate going over initial duration time
+    jest.runTimersToTime(350)
+
+    // shouldn't have been called cuz timer was reset
+    expect(onMouseRest).toHaveBeenCalledTimes(0)
+
+    // 5. simulate going over time for real
+    jest.runTimersToTime(150)
+
+    expect(onMouseRest).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('`withMouseRemainOver`', () => {
+  it('calls handler after mouse over & default 500 ms', () => {
+    const EnhancedAnchor = withMouseRemainOver()('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(500)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse move & default 500 ms', () => {
+    const EnhancedAnchor = withMouseRemainOver()('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(500)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse over & specified duration', () => {
+    const EnhancedAnchor = withMouseRemainOver(450)('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver-450={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(450)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse move & specified duration', () => {
+    const EnhancedAnchor = withMouseRemainOver(450)('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver-450={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(450)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call handler if mouse out happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRemainOver()('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate cancel event
+    anchorWrapper.simulate('mouseout')
+
+    // 4. simulate going over time
+    jest.runTimersToTime(350)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler if mouse down happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRemainOver()('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mousemove')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate cancel event
+    anchorWrapper.simulate('mousedown')
+
+    // 4. simulate going over time
+    jest.runTimersToTime(350)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not delay calling handler if trigger event happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRemainOver()('a')
+
+    let onMouseRemainOver = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOver={onMouseRemainOver}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseover')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate trigger again before time has expired
+    anchorWrapper.simulate('mousemove')
+
+    // 4. simulate going over initial duration time
+    jest.runTimersToTime(350)
+
+    // should've been called because retrigger should've been ignored
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+
+    // 5. simulate going over what could be the reset duration
+    jest.runTimersToTime(150)
+
+    expect(onMouseRemainOver).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('`withMouseRemainOut`', () => {
+  it('calls handler after mouse out & default 500 ms', () => {
+    const EnhancedAnchor = withMouseRemainOut()('a')
+
+    let onMouseRemainOut = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOut={onMouseRemainOut}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseout')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(500)
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls handler after mouse out & specified duration', () => {
+    const EnhancedAnchor = withMouseRemainOut(123)('a')
+
+    let onMouseRemainOut = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOut-123={onMouseRemainOut}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseout')
+
+    // 2. simulate going over time
+    jest.runTimersToTime(123)
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call handler if mouse over happens before duration expires', () => {
+    const EnhancedAnchor = withMouseRemainOut()('a')
+
+    let onMouseRemainOut = jest.fn()
+    let wrapper = shallow(
+      <EnhancedAnchor
+        href="http://www.benmvp.com/"
+        onMouseRemainOut={onMouseRemainOut}
+      />
+    )
+    let anchorWrapper = wrapper.find('a')
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(0)
+
+    // 1. simulate trigger
+    anchorWrapper.simulate('mouseout')
+
+    // 2. simulate some time passing
+    jest.runTimersToTime(150)
+
+    // 3. simulate cancel event
+    anchorWrapper.simulate('mouseover')
+
+    // 4. simulate going over time
+    jest.runTimersToTime(350)
+
+    expect(onMouseRemainOut).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
Implemented `withMouseRest`, `withMouseRemainOver` & `withMouseRemainOut` composite event HOCs within the mouse-related APIs. There are still other mouse-related APIs to implement