### PR TITLE
Fix(compose): Fix compose based on Flow typing tests

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,3 +7,6 @@
 [lints]
 
 [options]
+
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,3 @@ after_success:
   # 3. Generate changelog + release on Github
   - yarn run build
   - semantic-release pre && npm publish && semantic-release post
-
-# Build web bundle
-# before_deploy: yarn run bundle
-
-# Publish to NPM
-# deploy:
-#   skip_cleanup: true
-#   provider: script
-#   script:  ./_scripts/travis-deploy.sh
-#   on:
-#     branch: master
-#     node: "node"

--- a/flow-typed/npm/enzyme_v2.3.x.js
+++ b/flow-typed/npm/enzyme_v2.3.x.js
@@ -1,0 +1,109 @@
+// flow-typed signature: ec281a88a84a43aa73f8b0ca867a4855
+// flow-typed version: d7a8d069fa/enzyme_v2.3.x/flow_>=v0.53.x
+
+import * as React from 'react'
+
+declare module 'enzyme' {
+  declare type PredicateFunction<T: Wrapper> = (
+    wrapper: T,
+    index: number
+  ) => boolean
+  declare type NodeOrNodes = React.Node | Array<React.Node>
+  declare type EnzymeSelector = string | Class<React.Component<*, *>> | Object
+
+  // CheerioWrapper is a type alias for an actual cheerio instance
+  // TODO: Reference correct type from cheerio's type declarations
+  declare type CheerioWrapper = any
+
+  declare class Wrapper {
+    find(selector: EnzymeSelector): this,
+    findWhere(predicate: PredicateFunction<this>): this,
+    filter(selector: EnzymeSelector): this,
+    filterWhere(predicate: PredicateFunction<this>): this,
+    contains(nodeOrNodes: NodeOrNodes): boolean,
+    containsMatchingElement(node: React.Node): boolean,
+    containsAllMatchingElements(nodes: NodeOrNodes): boolean,
+    containsAnyMatchingElements(nodes: NodeOrNodes): boolean,
+    dive(option?: {context?: Object}): this,
+    exists(): boolean,
+    matchesElement(node: React.Node): boolean,
+    hasClass(className: string): boolean,
+    is(selector: EnzymeSelector): boolean,
+    isEmpty(): boolean,
+    not(selector: EnzymeSelector): this,
+    children(selector?: EnzymeSelector): this,
+    childAt(index: number): this,
+    parents(selector?: EnzymeSelector): this,
+    parent(): this,
+    closest(selector: EnzymeSelector): this,
+    render(): CheerioWrapper,
+    unmount(): this,
+    text(): string,
+    html(): string,
+    get(index: number): React.Node,
+    getNode(): React.Node,
+    getNodes(): Array<React.Node>,
+    getDOMNode(): HTMLElement | HTMLInputElement,
+    at(index: number): this,
+    first(): this,
+    last(): this,
+    state(key?: string): any,
+    context(key?: string): any,
+    props(): Object,
+    prop(key: string): any,
+    key(): string,
+    simulate(event: string, ...args: Array<any>): this,
+    setState(state: {}, callback?: Function): this,
+    setProps(props: {}): this,
+    setContext(context: Object): this,
+    instance(): React.Component<*, *>,
+    update(): this,
+    debug(): string,
+    type(): string | Function | null,
+    name(): string,
+    forEach(fn: (node: this, index: number) => mixed): this,
+    map<T>(fn: (node: this, index: number) => T): Array<T>,
+    reduce<T>(
+      fn: (value: T, node: this, index: number) => T,
+      initialValue?: T
+    ): Array<T>,
+    reduceRight<T>(
+      fn: (value: T, node: this, index: number) => T,
+      initialValue?: T
+    ): Array<T>,
+    some(selector: EnzymeSelector): boolean,
+    someWhere(predicate: PredicateFunction<this>): boolean,
+    every(selector: EnzymeSelector): boolean,
+    everyWhere(predicate: PredicateFunction<this>): boolean,
+    length: number,
+  }
+
+  declare export class ReactWrapper extends Wrapper {
+    constructor(nodes: NodeOrNodes, root: any, options?: ?Object): ReactWrapper,
+    mount(): this,
+    ref(refName: string): this,
+    detach(): void,
+  }
+
+  declare export class ShallowWrapper extends Wrapper {
+    equals(node: React.Node): boolean,
+    shallow(options?: {context?: Object}): ShallowWrapper,
+  }
+
+  declare export function shallow(
+    node: React.Node,
+    options?: {context?: Object}
+  ): ShallowWrapper
+  declare export function mount(
+    node: React.Node,
+    options?: {
+      context?: Object,
+      attachTo?: HTMLElement,
+      childContextTypes?: Object,
+    }
+  ): ReactWrapper
+  declare export function render(
+    node: React.Node,
+    options?: {context?: Object}
+  ): CheerioWrapper
+}

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -1,0 +1,569 @@
+// flow-typed signature: 5960ed076fe29ecf92f57584d68acf98
+// flow-typed version: b2a49dc910/jest_v20.x.x/flow_>=v0.39.x
+
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>,
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+}
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean,
+}
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void,
+}
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void,
+}
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean,
+}
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType,
+}
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void,
+}
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | RegExp): void,
+  toThrowError(message?: string | Error | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void,
+}
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+}
+
+type JestSpyType = {
+  calls: JestCallsType,
+}
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: () => void): void,
+}
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+}
+declare function fit(
+  name: string,
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void
+/** An individual test unit */
+declare var test: typeof it
+/** A disabled group of tests */
+declare var xdescribe: typeof describe
+/** A focused group of tests */
+declare var fdescribe: typeof describe
+/** A disabled individual test */
+declare var xit: typeof it
+/** A disabled individual test */
+declare var xtest: typeof it
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: {[name: string]: JestMatcher}): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void,
+}
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType
+
+/**
+ * The global Jamine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): {[methodName: string]: JestSpyType},
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void,
+}

--- a/package.json
+++ b/package.json
@@ -72,7 +72,15 @@
     }
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js"
+    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   },
   "peerDependencies": {
     "react": ">=15"

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,6 +1,7 @@
 // @flow
-import React from 'react'
-import type {ComponentType} from 'react'
+import React, {Component} from 'react'
+import type {ElementType, ComponentType} from 'react'
+import {getDisplayName} from './utils'
 
 type EventName = string
 type TimerEvent = EventName | EventName[]
@@ -15,6 +16,7 @@ type ComposerSettings = {
     event?: SyntheticEvent<>
   ) => boolean | void,
 }
+type InternalHandler = (eventName: EventName, event?: SyntheticEvent<>) => void
 
 const _omit = (props: {}, propToOmit: string): {} => {
   let propsCopy = {...props}
@@ -23,8 +25,6 @@ const _omit = (props: {}, propToOmit: string): {} => {
 
   return propsCopy
 }
-
-type InternalHandler = (eventName: EventName, event?: SyntheticEvent<>) => void
 
 const _eventNamesToHandlerLookup = (
   eventNames?: EventName[],
@@ -63,7 +63,7 @@ export default ({
     cancelEvents = Array.isArray(cancelEvent) ? cancelEvent : [cancelEvent]
   }
 
-  return (duration: number) => {
+  return (duration?: number = 0) => {
     let timeoutDuration = defaultDuration
     let durationSuffix = ''
 
@@ -77,13 +77,15 @@ export default ({
     // if the duration is passed the composite even prop name needs to be parameterized
     let compositeEventPropName = `${eventPropName}${durationSuffix}`
 
-    return <Props: {}>(Component: ComponentType<{}>): ComponentType<Props> => {
-      if (process.env.NODE_ENV !== 'production' && !Component) {
-        throw new Error('Component to enhance must be specified')
+    return <Props: {}>(Element: ElementType): ComponentType<Props> => {
+      if (process.env.NODE_ENV !== 'production' && !Element) {
+        throw new Error('Component/element to enhance must be specified')
       }
 
-      return class extends React.Component<Props> {
-        static displayName = `CompositeEvent-${eventPropName}${durationSuffix}`
+      let elementDisplayName = getDisplayName(Element)
+
+      return class CompositeEventWrapper extends Component<Props> {
+        static displayName = `${elementDisplayName}-${eventPropName}${durationSuffix}`
 
         _delayTimeout = null
 
@@ -121,6 +123,13 @@ export default ({
           // If no composite event handler was passed in, we can
           // quit early
           if (!onCompositeEvent) {
+            if (process.env.NODE_ENV !== 'production') {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `No handler was found for \`${compositeEventPropName}\` in \`<${elementDisplayName} />\`! Was this a typo? If not, you should consider avoiding using the composite event HOC to improve performance`
+              )
+            }
+
             return
           }
 
@@ -174,7 +183,7 @@ export default ({
           // a cancel event matches a trigger event, the composite event will never be triggered
 
           return (
-            <Component
+            <Element
               {...passThruProps}
               {...triggerEventHandlers}
               {...cancelEventHandlers}

--- a/src/compose.js
+++ b/src/compose.js
@@ -47,11 +47,14 @@ export default ({
   shouldResetTimerOnRetrigger = true,
   beforeHandle = () => true,
 }: ComposerSettings) => {
-  if (process.env.NODE_ENV !== 'production' && !eventPropName) {
-    throw new Error('`eventPropName` configuration must be specified')
-  }
-  if (process.env.NODE_ENV !== 'production' && !triggerEvent) {
-    throw new Error('`triggerEvent` configuration must be specified')
+  // istanbul ignore next
+  if (process.env.NODE_ENV !== 'production') {
+    if (!eventPropName) {
+      throw new Error('`eventPropName` configuration must be specified')
+    }
+    if (!triggerEvent) {
+      throw new Error('`triggerEvent` configuration must be specified')
+    }
   }
 
   let triggerEvents = Array.isArray(triggerEvent)
@@ -78,7 +81,7 @@ export default ({
     let compositeEventPropName = `${eventPropName}${durationSuffix}`
 
     return <Props: {}>(Element: ElementType): ComponentType<Props> => {
-      if (process.env.NODE_ENV !== 'production' && !Element) {
+      if (!Element && process.env.NODE_ENV !== 'production') {
         throw new Error('Component/element to enhance must be specified')
       }
 
@@ -120,9 +123,8 @@ export default ({
           // If a specific handler was passed, call that one first
           this._callSpecificHandler(eventName, e)
 
-          // If no composite event handler was passed in, we can
-          // quit early
           if (!onCompositeEvent) {
+            // istanbul ignore next
             if (process.env.NODE_ENV !== 'production') {
               // eslint-disable-next-line no-console
               console.warn(

--- a/src/compose.spec.js
+++ b/src/compose.spec.js
@@ -1,6 +1,9 @@
+// @flow
+/* eslint-disable no-console */
 import React from 'react'
 import {shallow, mount} from 'enzyme'
 import compose from './compose'
+import {getDisplayName} from './utils'
 
 const Dummy = () => <div />
 
@@ -20,15 +23,18 @@ jest.useFakeTimers()
 describe('compose', () => {
   describe('error handling', () => {
     it('throws an error if no configuration object is specified', () => {
+      // $FlowIgnore: error handling test case
       expect(() => compose()).toThrow()
     })
 
     it('throws an error if no configurations are specified', () => {
+      // $FlowIgnore: error handling test case
       expect(() => compose({})).toThrow()
     })
 
     it('throws an error if no `triggerEvent` is specified when `eventPropName` is', () => {
       expect(() =>
+        // $FlowIgnore: error handling test case
         compose({
           eventPropName: 'compositeEvent',
         })
@@ -37,6 +43,7 @@ describe('compose', () => {
 
     it('throws an error if no `eventPropName` is specified when `triggerEvent` is', () => {
       expect(() =>
+        // $FlowIgnore: error handling test case
         compose({
           triggerEvent: 'onClick',
         })
@@ -66,6 +73,7 @@ describe('compose', () => {
       })
 
       // throws an error because no Component was specified
+      // $FlowIgnore: error handling test case
       expect(() => withCompositeEvent()()).toThrow()
     })
 
@@ -190,6 +198,8 @@ describe('compose', () => {
       })
       const EnhancedDummy = withCompositeEvent()(Dummy)
 
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
         <EnhancedDummy onCompositeEvent={onCompositeEvent} />
@@ -211,6 +221,8 @@ describe('compose', () => {
       })
       const EnhancedDiv = withCompositeEvent()('div')
 
+      expect(getDisplayName(EnhancedDiv)).toBe('div-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(<EnhancedDiv onCompositeEvent={onCompositeEvent} />)
       let divWrapper = wrapper.find('div')
@@ -229,6 +241,7 @@ describe('compose', () => {
     })
 
     it('does not blow up when composite event handler is not passed', () => {
+      const warn = console.warn
       const withCompositeEvent = compose({
         eventPropName: 'onCompositeEvent',
         triggerEvent: ['onMouseDown', 'onMouseUp'],
@@ -238,9 +251,19 @@ describe('compose', () => {
       let wrapper = shallow(<EnhancedDiv />)
       let divWrapper = wrapper.find('div')
 
+      // override with mock function
+      // $FlowIgnore: mocking
+      console.warn = jest.fn()
+
       // verify that simulating trigger event even though composite even thandler
       // wasn't passed doesn't blow up
       expect(() => divWrapper.simulate('mousedown')).not.toThrow()
+
+      expect(console.warn).toHaveBeenCalledTimes(1)
+
+      // restore real implementation
+      // $FlowIgnore: mocking
+      console.warn = warn
     })
 
     it('does not blow up passing unsupported events as triggers', () => {
@@ -249,6 +272,8 @@ describe('compose', () => {
         triggerEvent: ['onMouseDown', 'onPressIn'],
       })
       const EnhancedSection = withCompositeEvent()('section')
+
+      expect(getDisplayName(EnhancedSection)).toBe('section-onCompositeEvent')
 
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
@@ -271,6 +296,8 @@ describe('compose', () => {
       })
       const EnhancedLabel = withCompositeEvent()('label')
 
+      expect(getDisplayName(EnhancedLabel)).toBe('label-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
         <EnhancedLabel onCompositeEvent={onCompositeEvent} />
@@ -291,6 +318,8 @@ describe('compose', () => {
         triggerEvent: 'onMouseEnter',
       })
       const EnhancedMain = withCompositeEvent()('main')
+
+      expect(getDisplayName(EnhancedMain)).toBe('main-onCompositeEvent')
 
       let onCompositeEvent = jest.fn()
       let onMouseEnter = jest.fn()
@@ -319,6 +348,8 @@ describe('compose', () => {
         triggerEvent: ['onClick', 'onKeyPress'],
       })
       const EnhancedSpan = withCompositeEvent()('span')
+
+      expect(getDisplayName(EnhancedSpan)).toBe('span-onCompositeEvent')
 
       let onCompositeEvent = jest.fn()
       let onClick = jest.fn()
@@ -352,6 +383,8 @@ describe('compose', () => {
       })
       const EnhancedNav = withCompositeEvent()('nav')
 
+      expect(getDisplayName(EnhancedNav)).toBe('nav-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(<EnhancedNav onCompositeEvent={onCompositeEvent} />)
       let navWrapper = wrapper.find('nav')
@@ -376,6 +409,10 @@ describe('compose', () => {
         triggerEvent: 'onMouseOver',
       })
       const EnhancedNav = withCompositeEventB()(withCompositeEventA()('nav'))
+
+      expect(getDisplayName(EnhancedNav)).toBe(
+        'nav-onCompositeEventA-onCompositeEventB'
+      )
 
       let onCompositeEventA = jest.fn()
       let onCompositeEventB = jest.fn()
@@ -443,6 +480,8 @@ describe('compose', () => {
       })
       const EnhancedDummy = withCompositeEvent()(Dummy)
 
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
         <EnhancedDummy onCompositeEvent={onCompositeEvent} />
@@ -477,6 +516,8 @@ describe('compose', () => {
 
       // specify delay override
       const EnhancedDummy = withCompositeEvent(300)(Dummy)
+
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent-300')
 
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
@@ -517,6 +558,8 @@ describe('compose', () => {
       })
       const EnhancedDummy = withCompositeEvent()(Dummy)
 
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent')
+
       let onCompositeEvent = jest.fn()
       let wrapper = shallow(
         <EnhancedDummy onCompositeEvent={onCompositeEvent} />
@@ -547,6 +590,8 @@ describe('compose', () => {
 
       // specify delay override
       const EnhancedDummy = withCompositeEvent(-300)(Dummy)
+
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent')
 
       let onCompositeEvent = jest.fn()
       let onCompositeEvent300 = jest.fn()
@@ -630,6 +675,7 @@ describe('compose', () => {
     })
 
     it('does not call composite event handler with generic name with delay override', () => {
+      const warn = console.warn
       const withCompositeEvent = compose({
         eventPropName: 'onCompositeEvent',
         triggerEvent: 'onDummyEvent',
@@ -639,7 +685,12 @@ describe('compose', () => {
       // specify delay override
       const EnhancedDummy = withCompositeEvent(500)(Dummy)
 
+      expect(getDisplayName(EnhancedDummy)).toBe('Dummy-onCompositeEvent-500')
+
       let onCompositeEvent = jest.fn()
+
+      // $FlowIgnore: mocking
+      console.warn = jest.fn()
 
       // use generic name instead of expected parameterized name
       let wrapper = shallow(
@@ -664,6 +715,12 @@ describe('compose', () => {
 
       // still not called because used the generic name
       expect(onCompositeEvent).toHaveBeenCalledTimes(0)
+
+      // verify we get the warning that we didn't add handler for `onCompositeEvent-500`
+      expect(console.warn).toHaveBeenCalledTimes(1)
+
+      // $FlowIgnore: mocking
+      console.warn = warn
     })
 
     it('calls multiple composite event handlers with different duration overrides at the right time', () => {
@@ -676,6 +733,10 @@ describe('compose', () => {
       // add multiple composite events
       const EnhancedDummy = withCompositeEvent(1000)(
         withCompositeEvent(450)(withCompositeEvent()(Dummy))
+      )
+
+      expect(getDisplayName(EnhancedDummy)).toBe(
+        'Dummy-onCompositeEvent-onCompositeEvent-450-onCompositeEvent-1000'
       )
 
       let onCompositeEvent = jest.fn()

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,11 @@
+// @flow
+import type {ElementType} from 'react'
+
+export const getDisplayName = (Element: ElementType): string => {
+  if (typeof Element === 'string') {
+    return Element
+  }
+
+  // $FlowFixMe: Need to figure out how to properly validate that Element is a class component to get `displayName` statically
+  return Element.displayName || Element.name || 'WrapperComponent'
+}

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,43 @@
+// @flow
+import React, {PureComponent} from 'react'
+import {getDisplayName} from './utils'
+
+describe('`getDisplayName`', () => {
+  it('return the the element name when passed a JSX element', () => {
+    expect(getDisplayName('a')).toBe('a')
+  })
+
+  it('returns the `displayName` static property of a component class', () => {
+    class MyComponent extends PureComponent<{}> {
+      static displayName = 'Foo'
+
+      render() {
+        return <div />
+      }
+    }
+
+    expect(getDisplayName(MyComponent)).toBe('Foo')
+  })
+
+  it('returns the name of a component class (no static `displayName`)', () => {
+    // eslint-disable-next-line react/no-multi-comp
+    class MyComponent extends PureComponent<{}> {
+      render() {
+        return <span />
+      }
+    }
+
+    expect(getDisplayName(MyComponent)).toBe('MyComponent')
+  })
+
+  it('return the name of stateless function', () => {
+    const MyComponent = () => <div />
+
+    expect(getDisplayName(MyComponent)).toBe('MyComponent')
+  })
+
+  it('return "WrapperComponent" for an unrecognized component type', () => {
+    // $FlowIgnore: error handling test case
+    expect(getDisplayName({})).toBe('WrapperComponent')
+  })
+})


### PR DESCRIPTION
As a result of Flow typing `compose.spec.js` more changes needed to be made to `compose`:

- `duration` in the HOC needed to be optional for Flow
- `Component` in the HOC should actually be an `ElementType` since it takes either intrinsic JSX or a Component
- Set an actual useful `displayName` for enhanced component (verified by new tests)
- Warn if a composite event handler isn't specified (verified by new tests)
- Unit tests fail if coverage is not 100%