### PR TITLE
feat(API): Implement mouse modifier key HOCs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 cache: yarn
 
 # Run the the validate script with code coverage
-script: yarn run validate -- -- --ci --coverage
+script: yarn run validate -- -- --ci --coverage --verbose
 
 # Scripts to run after validation tests run
 after_success:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
       "jest": true
     },
     "globals": {
-      "SyntheticEvent": false
+      "SyntheticEvent": false,
+      "SyntheticMouseEvent": false
     }
   },
   "jest": {

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -24,3 +24,65 @@ export const withMouseRemainOut = compose({
   defaultDuration: 500,
   cancelEvent: 'onMouseOver',
 })
+
+type MouseModifierKeySettings = {
+  eventPropName: string,
+  mouseEvent: string,
+  alt?: boolean,
+  ctrl?: boolean,
+  meta?: boolean,
+  shift?: boolean,
+}
+
+export const composeMouseModifierKey = ({
+  eventPropName,
+  mouseEvent,
+  alt = false,
+  ctrl = false,
+  meta = false,
+  shift = false,
+}: MouseModifierKeySettings) =>
+  compose({
+    eventPropName,
+    triggerEvent: mouseEvent,
+    beforeHandle: (handler, e?: SyntheticEvent<>) => {
+      let syntheticMouseEvent = ((e: any): SyntheticMouseEvent<>)
+
+      return (
+        syntheticMouseEvent &&
+        syntheticMouseEvent.altKey === alt &&
+        syntheticMouseEvent.ctrlKey === ctrl &&
+        syntheticMouseEvent.metaKey === meta &&
+        syntheticMouseEvent.shiftKey === shift
+      )
+    },
+  })
+
+export const withOnlyClick = composeMouseModifierKey({
+  eventPropName: 'onOnlyClick',
+  mouseEvent: 'onClick',
+})
+
+export const withAltClick = composeMouseModifierKey({
+  eventPropName: 'onAltClick',
+  mouseEvent: 'onClick',
+  alt: true,
+})
+
+export const withCtrlClick = composeMouseModifierKey({
+  eventPropName: 'onCtrlClick',
+  mouseEvent: 'onClick',
+  ctrl: true,
+})
+
+export const withMetaClick = composeMouseModifierKey({
+  eventPropName: 'onMetaClick',
+  mouseEvent: 'onClick',
+  meta: true,
+})
+
+export const withShiftClick = composeMouseModifierKey({
+  eventPropName: 'onShiftClick',
+  mouseEvent: 'onClick',
+  shift: true,
+})

--- a/src/mouse.md
+++ b/src/mouse.md
@@ -649,10 +649,10 @@ See related [`composeMouseModifierKey()`](#composemousemodifierkey), [`withOnlyC
 composeMouseModifierKey({
   eventPropName: string,
   mouseEvent: string,
-  ?alt: boolean = false,
-  ?ctrl: boolean = false,
-  ?meta: boolean = false,
-  ?shift: boolean = false
+  alt?: boolean = false,
+  ctrl?: boolean = false,
+  meta?: boolean = false,
+  shift?: boolean = false
 }): HigherOrderComponent
 ```
 


### PR DESCRIPTION
Implemented `composeMouseModifierKey` HOC composer, and `withOnlyClick`, `withAltClick`, `withCtrlClick`, `withMetaClick` & `withShiftClick` HOCs. Updated the docs to reflect the Flow way of showing optional properties.