### PR TITLE
feat(API): Implement mouse edge HOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 
 A collection of higher-order components (HOCs) to easily create composite events in React components.
 
-> `react-composite-events` is currently under alpha development and not available for general public use! Check out the [API Docs](#api-docs) for more info.
-
 `react-composite-events` is [stable](https://travis-ci.org/benmvp/react-composite-events), [dependency-free](https://david-dm.org/benmvp/react-composite-events#info=dependencies), [heavily-tested](https://coveralls.io/github/benmvp/react-composite-events?branch=master) and [well-documented](#api-docs).
 
 ## ToC

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     },
     "globals": {
       "SyntheticEvent": false,
-      "SyntheticMouseEvent": false
+      "SyntheticMouseEvent": false,
+      "HTMLElement": false
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "react-composite-events",
   "version": "0.0.0-semantically-released",
-  "description": "A collection of higher-order components (HOCs) to easily create composite events in React components",
+  "description":
+    "A collection of higher-order components (HOCs) to easily create composite events in React components",
   "author": "Ben Ilegbodu <ben@benmvp.com>",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -75,15 +76,7 @@
     }
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
-    "coverageThreshold": {
-      "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100,
-        "statements": 100
-      }
-    }
+    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js"
   },
   "peerDependencies": {
     "react": ">=15"

--- a/src/compose.js
+++ b/src/compose.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react'
 import type {ElementType, ComponentType} from 'react'
 import {getDisplayName} from './utils'
 
-type EventName = string
+export type EventName = string
 type TimerEvent = EventName | EventName[]
 type EventHandler = (event?: SyntheticEvent<>) => void
 type CompositeEventHandler = EventHandler

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -1,5 +1,86 @@
 // @flow
 import compose from './compose'
+import type {EventName} from './compose'
+
+type EdgeLocation = 'left' | 'right' | 'top' | 'bottom'
+type EdgeDirection = 'enter' | 'leave'
+
+type MouseEdgeSettings = {
+  eventPropName: EventName,
+  direction: EdgeDirection,
+  location: EdgeLocation,
+}
+
+type MouseModifierKeySettings = {
+  eventPropName: EventName,
+  mouseEvent: EventName,
+  alt?: boolean,
+  ctrl?: boolean,
+  meta?: boolean,
+  shift?: boolean,
+}
+
+const composeMouseEdge = ({
+  eventPropName,
+  direction,
+  location,
+}: MouseEdgeSettings) =>
+  compose({
+    eventPropName,
+    triggerEvent: direction === 'enter' ? 'onMouseEnter' : 'onMouseLeave',
+    beforeHandle: (handler, e?: SyntheticEvent<>) => {
+      let {currentTarget, screenX, screenY} = ((e: any): SyntheticMouseEvent<>)
+
+      let boundingClientRect = {top: 0, left: 0, bottom: 0, right: 0}
+
+      if (currentTarget instanceof HTMLElement) {
+        boundingClientRect = currentTarget.getBoundingClientRect()
+      }
+
+      let {
+        top,
+        left,
+        bottom,
+        right,
+      }: {
+        top: number,
+        left: number,
+        bottom: number,
+        right: number,
+      } = boundingClientRect
+
+      return (
+        (location === 'left' && screenX <= left) ||
+        (location === 'right' && screenX >= right) ||
+        (location === 'top' && screenY <= top) ||
+        (location === 'bottom' && screenY >= bottom)
+      )
+    },
+  })
+
+export const composeMouseModifierKey = ({
+  eventPropName,
+  mouseEvent,
+  alt = false,
+  ctrl = false,
+  meta = false,
+  shift = false,
+}: MouseModifierKeySettings) =>
+  compose({
+    eventPropName,
+    triggerEvent: mouseEvent,
+    beforeHandle: (handler, e?: SyntheticEvent<>) => {
+      let syntheticMouseEvent = ((e: any): SyntheticMouseEvent<>)
+
+      return (
+        syntheticMouseEvent &&
+        syntheticMouseEvent.altKey === alt &&
+        syntheticMouseEvent.ctrlKey === ctrl &&
+        syntheticMouseEvent.metaKey === meta &&
+        syntheticMouseEvent.shiftKey === shift
+      )
+    },
+  })
 
 export const withMouseRest = compose({
   eventPropName: 'onMouseRest',
@@ -25,38 +106,53 @@ export const withMouseRemainOut = compose({
   cancelEvent: 'onMouseOver',
 })
 
-type MouseModifierKeySettings = {
-  eventPropName: string,
-  mouseEvent: string,
-  alt?: boolean,
-  ctrl?: boolean,
-  meta?: boolean,
-  shift?: boolean,
-}
+export const withMouseEnterLeft = composeMouseEdge({
+  eventPropName: 'onMouseEnterLeft',
+  direction: 'enter',
+  location: 'left',
+})
 
-export const composeMouseModifierKey = ({
-  eventPropName,
-  mouseEvent,
-  alt = false,
-  ctrl = false,
-  meta = false,
-  shift = false,
-}: MouseModifierKeySettings) =>
-  compose({
-    eventPropName,
-    triggerEvent: mouseEvent,
-    beforeHandle: (handler, e?: SyntheticEvent<>) => {
-      let syntheticMouseEvent = ((e: any): SyntheticMouseEvent<>)
+export const withMouseEnterRight = composeMouseEdge({
+  eventPropName: 'onMouseEnterRight',
+  direction: 'enter',
+  location: 'right',
+})
 
-      return (
-        syntheticMouseEvent &&
-        syntheticMouseEvent.altKey === alt &&
-        syntheticMouseEvent.ctrlKey === ctrl &&
-        syntheticMouseEvent.metaKey === meta &&
-        syntheticMouseEvent.shiftKey === shift
-      )
-    },
-  })
+export const withMouseEnterTop = composeMouseEdge({
+  eventPropName: 'onMouseEnterTop',
+  direction: 'enter',
+  location: 'top',
+})
+
+export const withMouseEnterBottom = composeMouseEdge({
+  eventPropName: 'onMouseEnterBottom',
+  direction: 'enter',
+  location: 'bottom',
+})
+
+export const withMouseLeaveLeft = composeMouseEdge({
+  eventPropName: 'onMouseLeaveLeft',
+  direction: 'leave',
+  location: 'left',
+})
+
+export const withMouseLeaveRight = composeMouseEdge({
+  eventPropName: 'onMouseLeaveRight',
+  direction: 'leave',
+  location: 'right',
+})
+
+export const withMouseLeaveTop = composeMouseEdge({
+  eventPropName: 'onMouseLeaveTop',
+  direction: 'leave',
+  location: 'top',
+})
+
+export const withMouseLeaveBottom = composeMouseEdge({
+  eventPropName: 'onMouseLeaveBottom',
+  direction: 'leave',
+  location: 'bottom',
+})
 
 export const withOnlyClick = composeMouseModifierKey({
   eventPropName: 'onOnlyClick',

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -29,25 +29,17 @@ const composeMouseEdge = ({
     eventPropName,
     triggerEvent: direction === 'enter' ? 'onMouseEnter' : 'onMouseLeave',
     beforeHandle: (handler, e?: SyntheticEvent<>) => {
-      let {currentTarget, screenX, screenY} = ((e: any): SyntheticMouseEvent<>)
-
-      let boundingClientRect = {top: 0, left: 0, bottom: 0, right: 0}
-
-      if (currentTarget instanceof HTMLElement) {
-        boundingClientRect = currentTarget.getBoundingClientRect()
+      if (!e) {
+        return false
       }
 
-      let {
-        top,
-        left,
-        bottom,
-        right,
-      }: {
-        top: number,
-        left: number,
-        bottom: number,
-        right: number,
-      } = boundingClientRect
+      let {screenX, screenY, currentTarget} = ((e: any): SyntheticMouseEvent<>)
+
+      if (!(currentTarget instanceof HTMLElement)) {
+        return false
+      }
+
+      let {top, left, bottom, right} = currentTarget.getBoundingClientRect()
 
       return (
         (location === 'left' && screenX <= left) ||

--- a/src/mouse.spec.js
+++ b/src/mouse.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
-import {shallow} from 'enzyme'
+import {shallow, mount} from 'enzyme'
+import type {ReactWrapper} from 'enzyme'
 import {
   withMouseRest,
   withMouseRemainOut,
@@ -10,10 +11,39 @@ import {
   withAltClick,
   withCtrlClick,
   withMetaClick,
-  withShiftClick
+  withShiftClick,
+  withMouseEnterLeft,
+  withMouseEnterRight,
+  withMouseEnterTop,
+  withMouseEnterBottom,
+  withMouseLeaveLeft,
+  withMouseLeaveRight,
+  withMouseLeaveTop,
+  withMouseLeaveBottom
 } from './mouse'
 
 jest.useFakeTimers()
+
+const overrideBoundingRect = (
+  wrapper: ReactWrapper,
+  {top = 50, left = 50, bottom = 150, right = 150} = {}
+): ReactWrapper => {
+  let newWrapper = wrapper
+
+  // $FlowIgnore
+  newWrapper.getDOMNode().getBoundingClientRect = () => ({
+    top,
+    left,
+    bottom,
+    right,
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  })
+
+  return newWrapper
+}
 
 describe('`withMouseRest`', () => {
   it('calls handler after mouse over & default 500 ms', () => {
@@ -799,5 +829,725 @@ describe('`withShiftClick`', () => {
     divWrapper.simulate('click', fakeEventObject)
 
     expect(onShiftClick).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('`withMouseEnterLeft`', () => {
+  it('calls handler when mouse enters from the left side', () => {
+    const EnhancedDiv = withMouseEnterLeft()('div')
+
+    let onMouseEnterLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterLeft={onMouseEnterLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse enters from the right side', () => {
+    const EnhancedDiv = withMouseEnterLeft()('div')
+
+    let onMouseEnterLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterLeft={onMouseEnterLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterLeft).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse leaves from the left side', () => {
+    const EnhancedDiv = withMouseEnterLeft()('div')
+
+    let onMouseEnterLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterLeft={onMouseEnterLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseEnterLeft).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse enters from top-left corner', () => {
+    const EnhancedDiv = withMouseEnterLeft()('div')
+
+    let onMouseEnterLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterLeft={onMouseEnterLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse enters from bottom-left corner', () => {
+    const EnhancedDiv = withMouseEnterLeft()('div')
+
+    let onMouseEnterLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterLeft={onMouseEnterLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseEnterRight`', () => {
+  it('calls handler when mouse enters from the right side', () => {
+    const EnhancedDiv = withMouseEnterRight()('div')
+
+    let onMouseEnterRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterRight={onMouseEnterRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterRight).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse enters from the left side', () => {
+    const EnhancedDiv = withMouseEnterRight()('div')
+
+    let onMouseEnterRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterRight={onMouseEnterRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterRight).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse leaves from the right side', () => {
+    const EnhancedDiv = withMouseEnterRight()('div')
+
+    let onMouseEnterRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterRight={onMouseEnterRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseEnterRight).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse enters from top-right corner', () => {
+    const EnhancedDiv = withMouseEnterRight()('div')
+
+    let onMouseEnterRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterRight={onMouseEnterRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterRight).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse enters from bottom-right corner', () => {
+    const EnhancedDiv = withMouseEnterRight()('div')
+
+    let onMouseEnterRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterRight={onMouseEnterRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterRight).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseEnterTop`', () => {
+  it('calls handler when mouse enters from the top side', () => {
+    const EnhancedDiv = withMouseEnterTop()('div')
+
+    let onMouseEnterTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterTop={onMouseEnterTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterTop).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse enters from the bottom side', () => {
+    const EnhancedDiv = withMouseEnterTop()('div')
+
+    let onMouseEnterTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterTop={onMouseEnterTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterTop).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse leaves from the top side', () => {
+    const EnhancedDiv = withMouseEnterTop()('div')
+
+    let onMouseEnterTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterTop={onMouseEnterTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseEnterTop).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse enters from top-left corner', () => {
+    const EnhancedDiv = withMouseEnterTop()('div')
+
+    let onMouseEnterTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterTop={onMouseEnterTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterTop).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse enters from top-right corner', () => {
+    const EnhancedDiv = withMouseEnterTop()('div')
+
+    let onMouseEnterTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterTop={onMouseEnterTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterTop).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseEnterBottom`', () => {
+  it('calls handler when mouse enters from the bottom side', () => {
+    const EnhancedDiv = withMouseEnterBottom()('div')
+
+    let onMouseEnterBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterBottom={onMouseEnterBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse enters from the top side', () => {
+    const EnhancedDiv = withMouseEnterBottom()('div')
+
+    let onMouseEnterBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterBottom={onMouseEnterBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterBottom).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse leaves from the bottom side', () => {
+    const EnhancedDiv = withMouseEnterBottom()('div')
+
+    let onMouseEnterBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterBottom={onMouseEnterBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseEnterBottom).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse enters from bottom-left corner', () => {
+    const EnhancedDiv = withMouseEnterBottom()('div')
+
+    let onMouseEnterBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterBottom={onMouseEnterBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse enters from bottom-right corner', () => {
+    const EnhancedDiv = withMouseEnterBottom()('div')
+
+    let onMouseEnterBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseEnterBottom={onMouseEnterBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseEnterBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseEnterBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseLeaveLeft`', () => {
+  it('calls handler when mouse leaves from the left side', () => {
+    const EnhancedDiv = withMouseLeaveLeft()('div')
+
+    let onMouseLeaveLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveLeft={onMouseLeaveLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse leaves from the right side', () => {
+    const EnhancedDiv = withMouseLeaveLeft()('div')
+
+    let onMouseLeaveLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveLeft={onMouseLeaveLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveLeft).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse enters from the left side', () => {
+    const EnhancedDiv = withMouseLeaveLeft()('div')
+
+    let onMouseLeaveLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveLeft={onMouseLeaveLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseLeaveLeft).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse leaves from top-left corner', () => {
+    const EnhancedDiv = withMouseLeaveLeft()('div')
+
+    let onMouseLeaveLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveLeft={onMouseLeaveLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse leaves from bottom-left corner', () => {
+    const EnhancedDiv = withMouseLeaveLeft()('div')
+
+    let onMouseLeaveLeft = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveLeft={onMouseLeaveLeft} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveLeft).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveLeft.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseLeaveRight`', () => {
+  it('calls handler when mouse leaves from the right side', () => {
+    const EnhancedDiv = withMouseLeaveRight()('div')
+
+    let onMouseLeaveRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveRight={onMouseLeaveRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveRight).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse leaves from the left side', () => {
+    const EnhancedDiv = withMouseLeaveRight()('div')
+
+    let onMouseLeaveRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveRight={onMouseLeaveRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveRight).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse enters from the right side', () => {
+    const EnhancedDiv = withMouseLeaveRight()('div')
+
+    let onMouseLeaveRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveRight={onMouseLeaveRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 100,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseLeaveRight).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse leaves from top-right corner', () => {
+    const EnhancedDiv = withMouseLeaveRight()('div')
+
+    let onMouseLeaveRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveRight={onMouseLeaveRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveRight).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse leaves from bottom-right corner', () => {
+    const EnhancedDiv = withMouseLeaveRight()('div')
+
+    let onMouseLeaveRight = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveRight={onMouseLeaveRight} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveRight).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveRight.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseLeaveTop`', () => {
+  it('calls handler when mouse leaves from the top side', () => {
+    const EnhancedDiv = withMouseLeaveTop()('div')
+
+    let onMouseLeaveTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveTop={onMouseLeaveTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveTop).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse leaves from the bottom side', () => {
+    const EnhancedDiv = withMouseLeaveTop()('div')
+
+    let onMouseLeaveTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveTop={onMouseLeaveTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveTop).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse enters from the top side', () => {
+    const EnhancedDiv = withMouseLeaveTop()('div')
+
+    let onMouseLeaveTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveTop={onMouseLeaveTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseLeaveTop).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse leaves from top-left corner', () => {
+    const EnhancedDiv = withMouseLeaveTop()('div')
+
+    let onMouseLeaveTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveTop={onMouseLeaveTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveTop).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse leaves from top-right corner', () => {
+    const EnhancedDiv = withMouseLeaveTop()('div')
+
+    let onMouseLeaveTop = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveTop={onMouseLeaveTop} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveTop).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveTop.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+})
+
+describe('`withMouseLeaveBottom`', () => {
+  it('calls handler when mouse leaves from the bottom side', () => {
+    const EnhancedDiv = withMouseLeaveBottom()('div')
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveBottom={onMouseLeaveBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not call handler when mouse leaves from the top side', () => {
+    const EnhancedDiv = withMouseLeaveBottom()('div')
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveBottom={onMouseLeaveBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 50,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not call handler when mouse enters from the bottom side', () => {
+    const EnhancedDiv = withMouseLeaveBottom()('div')
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveBottom={onMouseLeaveBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 100,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseenter', fakeEventObject)
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(0)
+  })
+
+  it('calls handler when mouse leaves from bottom-left corner', () => {
+    const EnhancedDiv = withMouseLeaveBottom()('div')
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveBottom={onMouseLeaveBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 50,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('calls handler when mouse leaves from bottom-right corner', () => {
+    const EnhancedDiv = withMouseLeaveBottom()('div')
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(<EnhancedDiv onMouseLeaveBottom={onMouseLeaveBottom} />)
+    let divWrapper = overrideBoundingRect(wrapper.find('div'))
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    divWrapper.simulate('mouseleave', fakeEventObject)
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(1)
+    expect(onMouseLeaveBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
   })
 })

--- a/src/mouse.spec.js
+++ b/src/mouse.spec.js
@@ -24,6 +24,8 @@ import {
 
 jest.useFakeTimers()
 
+const Dummy = () => <div />
+
 const overrideBoundingRect = (
   wrapper: ReactWrapper,
   {top = 50, left = 50, bottom = 150, right = 150} = {}
@@ -1549,5 +1551,43 @@ describe('`withMouseLeaveBottom`', () => {
 
     expect(onMouseLeaveBottom).toHaveBeenCalledTimes(1)
     expect(onMouseLeaveBottom.mock.calls[0][0]).toMatchObject(fakeEventObject)
+  })
+
+  it('does not blow up when no event object is passed on trigger event', () => {
+    const EnhancedSampleDummy = withMouseLeaveBottom()(Dummy)
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(
+      <EnhancedSampleDummy onMouseLeaveBottom={onMouseLeaveBottom} />
+    )
+    let dummyWrapper = wrapper.find(Dummy)
+
+    // simulate trigger event
+    let triggerEvent = () => dummyWrapper.prop('onMouseLeave')()
+
+    expect(triggerEvent).not.toThrow()
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not blow up when trigger event passes an event that is not a mouse event', () => {
+    const EnhancedSampleDummy = withMouseLeaveBottom()(Dummy)
+
+    let onMouseLeaveBottom = jest.fn()
+    let wrapper = mount(
+      <EnhancedSampleDummy onMouseLeaveBottom={onMouseLeaveBottom} />
+    )
+    let dummyWrapper = wrapper.find(Dummy)
+    let fakeEventObject = {
+      screenX: 150,
+      screenY: 150,
+    }
+
+    // simulate trigger event
+    let triggerEvent = () => dummyWrapper.prop('onMouseLeave')(fakeEventObject)
+
+    expect(triggerEvent).not.toThrow()
+
+    expect(onMouseLeaveBottom).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
Implemented `withMouseEnter*` & `withMouseLeave*` edge HOCs that trigger when the mouse enters/leaves the edge of a DOM element.

Also `compose` exports `EventName` type